### PR TITLE
chore: GitHub repo hygiene — PR template, Dependabot, stale bot, release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /mcp-server
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    reviewers:
+      - rutvij26
+    labels:
+      - dependencies

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What
+<!-- One sentence: what does this PR do? -->
+
+Closes #
+
+## Why
+<!-- Why is this change needed? -->
+
+## Checklist
+- [ ] Tests added / updated
+- [ ] `npm run build` passes
+- [ ] Linked issue in "Closes #N" above
+- [ ] Self-reviewed diff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        working-directory: mcp-server
+        run: npm ci
+
+      - name: Build
+        working-directory: mcp-server
+        run: npm run build
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "No activity in 60 days. Labeling as stale — will close in 14 days unless updated."
+          stale-pr-message: "No activity in 30 days. Labeling as stale — will close in 14 days unless updated."
+          close-issue-message: "Closed due to inactivity. Reopen if still relevant."
+          close-pr-message: "Closed due to inactivity. Reopen if still relevant."
+          days-before-issue-stale: 60
+          days-before-pr-stale: 30
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "pinned,security"


### PR DESCRIPTION
## What

Closes #31

Adds missing GitHub repository infrastructure to make the project maintainable long-term.

## Changes

- **PR template** — auto-fills body with issue link + checklist on every new PR
- **Dependabot** — weekly Monday npm updates for `mcp-server`, auto-assigns @rutvij26
- **Stale bot** — labels issues after 60d inactivity, closes after 14 more days; PRs at 30d
- **Release workflow** — triggers on `v*.*.*` tags, builds, then creates GitHub Release with auto-generated notes
- **Repo description + topics** — set description and 7 topics (`chess`, `mcp`, `model-context-protocol`, `claude`, `stockfish`, `typescript`, `lichess`)

## Checklist
- [x] No code changes — infra/config only
- [x] Build unaffected
- [x] Linked issue above