### PR TITLE
fix: update tests to use axios mocks instead of global.fetch

### DIFF
--- a/mcp-server/src/engines/lichess-eval.test.ts
+++ b/mcp-server/src/engines/lichess-eval.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import axios from "axios";
 import { getCloudEval } from "./lichess-eval.js";
 
 // ---------------------------------------------------------------------------
-// Mock global fetch
+// Mock axios
 // ---------------------------------------------------------------------------
 
 function makeCloudEvalResponse(depth = 24, pvs = [
@@ -17,12 +18,15 @@ function makeCloudEvalResponse(depth = 24, pvs = [
   };
 }
 
-function mockFetch(status: number, body: unknown) {
-  return vi.spyOn(global, "fetch").mockResolvedValueOnce({
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  } as Response);
+function mockAxios(status: number, body: unknown) {
+  if (status >= 200 && status < 300) {
+    return vi.spyOn(axios, "get").mockResolvedValueOnce({ data: body, status });
+  }
+  const err = Object.assign(new Error(`HTTP ${status}`), {
+    isAxiosError: true,
+    response: { status, data: body },
+  });
+  return vi.spyOn(axios, "get").mockRejectedValueOnce(err);
 }
 
 beforeEach(() => {
@@ -41,64 +45,64 @@ describe("getCloudEval", () => {
   const FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
   it("returns null when the position is not in the cloud database (404)", async () => {
-    mockFetch(404, null);
+    mockAxios(404, null);
     const result = await getCloudEval(FEN);
     expect(result).toBeNull();
   });
 
   it("returns null on a non-ok response other than 404", async () => {
-    mockFetch(500, null);
+    mockAxios(500, null);
     const result = await getCloudEval(FEN);
     expect(result).toBeNull();
   });
 
-  it("returns null when fetch throws a network error", async () => {
-    vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("Network failure"));
+  it("returns null when axios throws a network error", async () => {
+    vi.spyOn(axios, "get").mockRejectedValueOnce(new Error("Network failure"));
     const result = await getCloudEval(FEN);
     expect(result).toBeNull();
   });
 
   it("returns an array of UCIAnalysisLine on success", async () => {
-    mockFetch(200, makeCloudEvalResponse());
+    mockAxios(200, makeCloudEvalResponse());
     const result = await getCloudEval(FEN);
     expect(Array.isArray(result)).toBe(true);
     expect(result!.length).toBe(2);
   });
 
   it("maps depth correctly from the response", async () => {
-    mockFetch(200, makeCloudEvalResponse(28));
+    mockAxios(200, makeCloudEvalResponse(28));
     const result = await getCloudEval(FEN);
     expect(result![0]!.depth).toBe(28);
   });
 
   it("maps score_cp from pv.cp", async () => {
-    mockFetch(200, makeCloudEvalResponse(24, [{ moves: "e2e4", cp: 42 }]));
+    mockAxios(200, makeCloudEvalResponse(24, [{ moves: "e2e4", cp: 42 }]));
     const result = await getCloudEval(FEN);
     expect(result![0]!.score_cp).toBe(42);
     expect(result![0]!.score_mate).toBeNull();
   });
 
   it("maps score_mate when pv has mate", async () => {
-    mockFetch(200, makeCloudEvalResponse(24, [{ moves: "e2e4", mate: 3 }]));
+    mockAxios(200, makeCloudEvalResponse(24, [{ moves: "e2e4", mate: 3 }]));
     const result = await getCloudEval(FEN);
     expect(result![0]!.score_mate).toBe(3);
     expect(result![0]!.score_cp).toBeNull();
   });
 
   it("splits pv moves into an array", async () => {
-    mockFetch(200, makeCloudEvalResponse(24, [{ moves: "e2e4 e7e5 g1f3", cp: 10 }]));
+    mockAxios(200, makeCloudEvalResponse(24, [{ moves: "e2e4 e7e5 g1f3", cp: 10 }]));
     const result = await getCloudEval(FEN);
     expect(result![0]!.pv).toEqual(["e2e4", "e7e5", "g1f3"]);
   });
 
   it("handles leading/trailing whitespace in pv moves", async () => {
-    mockFetch(200, makeCloudEvalResponse(24, [{ moves: "  e2e4 e7e5  ", cp: 5 }]));
+    mockAxios(200, makeCloudEvalResponse(24, [{ moves: "  e2e4 e7e5  ", cp: 5 }]));
     const result = await getCloudEval(FEN);
     expect(result![0]!.pv).toEqual(["e2e4", "e7e5"]);
   });
 
   it("sets multipv_rank starting from 1", async () => {
-    mockFetch(200, makeCloudEvalResponse(24, [
+    mockAxios(200, makeCloudEvalResponse(24, [
       { moves: "e2e4", cp: 30 },
       { moves: "d2d4", cp: 20 },
       { moves: "c2c4", cp: 15 },
@@ -110,21 +114,21 @@ describe("getCloudEval", () => {
   });
 
   it("passes multiPv parameter to the URL", async () => {
-    const spy = mockFetch(200, makeCloudEvalResponse());
+    const spy = mockAxios(200, makeCloudEvalResponse());
     await getCloudEval(FEN, 5);
     const calledUrl = (spy.mock.calls[0]![0] as string);
     expect(calledUrl).toContain("multiPv=5");
   });
 
   it("includes the FEN in the request URL", async () => {
-    const spy = mockFetch(200, makeCloudEvalResponse());
+    const spy = mockAxios(200, makeCloudEvalResponse());
     await getCloudEval(FEN, 3);
     const calledUrl = (spy.mock.calls[0]![0] as string);
     expect(calledUrl).toContain("fen=");
   });
 
   it("defaults multiPv to 3 when not specified", async () => {
-    const spy = mockFetch(200, makeCloudEvalResponse());
+    const spy = mockAxios(200, makeCloudEvalResponse());
     await getCloudEval(FEN);
     const calledUrl = (spy.mock.calls[0]![0] as string);
     expect(calledUrl).toContain("multiPv=3");

--- a/mcp-server/src/tools/analyze-game.test.ts
+++ b/mcp-server/src/tools/analyze-game.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
 import type { UCIAnalysisLine } from "../types/index.js";
 
 // ---------------------------------------------------------------------------
@@ -7,6 +8,7 @@ import type { UCIAnalysisLine } from "../types/index.js";
 
 vi.mock("../engines/stockfish.js", () => ({
   analyzePosition: vi.fn(),
+  isReady: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../engines/lichess-eval.js", () => ({
@@ -182,21 +184,20 @@ describe("handleAnalyzeGame — URL resolution", () => {
   });
 
   it("attempts to fetch a Lichess game by ID from a URL", async () => {
-    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      text: async () => "",
-    } as Response);
+    const axiosSpy = vi.spyOn(axios, "get").mockRejectedValueOnce(
+      Object.assign(new Error("404"), { response: { status: 404 } })
+    );
 
     await expect(
       handleAnalyzeGame({ game_url: "https://lichess.org/abcd1234" })
     ).rejects.toThrow();
 
-    // Verify it called fetch with the Lichess export endpoint
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining("lichess.org/game/export/abcd1234")
+    // Verify it called axios with the Lichess export endpoint
+    expect(axiosSpy).toHaveBeenCalledWith(
+      expect.stringContaining("lichess.org/game/export/abcd1234"),
+      expect.anything()
     );
-    fetchSpy.mockRestore();
+    axiosSpy.mockRestore();
   });
 
   it("throws when no PGN source is provided", async () => {


### PR DESCRIPTION
## What

Closes #33

## Why

Tests were spying on `global.fetch` but the codebase was migrated to axios. This caused 12 test failures in CI on PR #32.

## Changes

- `analyze-game.test.ts` — add `isReady` to stockfish mock; replace `global.fetch` spy with `axios.get` spy in URL resolution test
- `lichess-eval.test.ts` — replace `mockFetch` helper (global.fetch spy) with `mockAxios` helper (axios.get spy)

## Checklist
- [x] 151/151 tests passing locally
- [x] No logic changes — test fixes only
- [x] Linked issue above