### PR TITLE
feat: Stockfish Worker Thread pool — parallel position analysis

### DIFF
--- a/mcp-server/src/engines/stockfish-pool.test.ts
+++ b/mcp-server/src/engines/stockfish-pool.test.ts
@@ -1,0 +1,274 @@
+/**
+ * stockfish-pool.test.ts
+ *
+ * Unit tests for the Stockfish worker pool.
+ * All Worker Thread creation is mocked — no real engine is started.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { UCIAnalysisLine } from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Mock worker_threads so no real worker process is spawned
+// ---------------------------------------------------------------------------
+
+type WorkerEventMap = {
+  message: ((msg: unknown) => void)[];
+  error: ((err: Error) => void)[];
+  exit: ((code: number) => void)[];
+};
+
+interface MockWorker {
+  postMessage: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  _emit: (event: keyof WorkerEventMap, ...args: unknown[]) => void;
+  _listeners: WorkerEventMap;
+}
+
+function createMockWorker(): MockWorker {
+  const listeners: WorkerEventMap = { message: [], error: [], exit: [] };
+
+  const w: MockWorker = {
+    postMessage: vi.fn(),
+    terminate: vi.fn().mockResolvedValue(undefined),
+    _listeners: listeners,
+    _emit(event: keyof WorkerEventMap, ...args: unknown[]) {
+      const handlers = listeners[event] as ((...a: unknown[]) => void)[];
+      for (const handler of [...handlers]) {
+        handler(...args);
+      }
+    },
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const key = event as keyof WorkerEventMap;
+      if (listeners[key]) {
+        (listeners[key] as ((...a: unknown[]) => void)[]).push(handler);
+      }
+      return w;
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const key = event as keyof WorkerEventMap;
+      if (listeners[key]) {
+        const idx = (listeners[key] as ((...a: unknown[]) => void)[]).indexOf(handler);
+        if (idx !== -1) {
+          (listeners[key] as ((...a: unknown[]) => void)[]).splice(idx, 1);
+        }
+      }
+      return w;
+    }),
+  };
+  return w;
+}
+
+const mockWorkers: MockWorker[] = [];
+
+vi.mock("worker_threads", () => ({
+  // Must use `function` (not arrow) so `new Worker()` works as a constructor.
+  // Returning an explicit object from a constructor function overrides `this`.
+  Worker: vi.fn(function (_path: string, _opts: unknown) {
+    const w = createMockWorker();
+    mockWorkers.push(w);
+    return w;
+  }),
+  workerData: {},
+  parentPort: null,
+  isMainThread: true,
+}));
+
+// ---------------------------------------------------------------------------
+// Re-import module under test AFTER mocking
+// ---------------------------------------------------------------------------
+
+// We import the pool functions dynamically after each reset so the module
+// state is clean per test group. For simplicity, we use a fresh vi.resetModules
+// and dynamic import in each describe block.
+
+async function loadPool() {
+  const mod = await import("./stockfish-pool.js");
+  return mod;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResultLine(cp = 30): UCIAnalysisLine {
+  return {
+    depth: 12,
+    score_cp: cp,
+    score_mate: null,
+    pv: ["e2e4"],
+    multipv_rank: 1,
+  };
+}
+
+/**
+ * Simulate a worker becoming "ready" by emitting the 'ready' message.
+ * Called after initPool() is invoked but before it resolves.
+ */
+function emitReadyOnAll() {
+  for (const w of mockWorkers) {
+    w._emit("message", { type: "ready" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StockfishPool — isPoolReady", () => {
+  beforeEach(() => {
+    mockWorkers.length = 0;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false before initPool is called", async () => {
+    const { isPoolReady } = await loadPool();
+    expect(isPoolReady()).toBe(false);
+  });
+
+  it("returns true after pool initializes successfully", async () => {
+    const { initPool, isPoolReady, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(1);
+    emitReadyOnAll();
+    await initPromise;
+
+    expect(isPoolReady()).toBe(true);
+    await shutdownPool();
+  });
+});
+
+describe("StockfishPool — analyzePositionParallel", () => {
+  beforeEach(() => {
+    mockWorkers.length = 0;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches analysis to a worker and resolves with the result", async () => {
+    const { initPool, analyzePositionParallel, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(1);
+    emitReadyOnAll();
+    await initPromise;
+
+    const analysisPromise = analyzePositionParallel(
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      { depth: 12, multiPv: 1 }
+    );
+
+    // Simulate worker returning a result
+    const worker = mockWorkers[0]!;
+    worker._emit("message", { type: "result", lines: [makeResultLine(30)] });
+
+    const lines = await analysisPromise;
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.score_cp).toBe(30);
+
+    await shutdownPool();
+  });
+
+  it("rejects when the worker returns an error message", async () => {
+    const { initPool, analyzePositionParallel, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(1);
+    emitReadyOnAll();
+    await initPromise;
+
+    const analysisPromise = analyzePositionParallel(
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      { depth: 12, multiPv: 1 }
+    );
+
+    const worker = mockWorkers[0]!;
+    worker._emit("message", { type: "error", message: "Engine crashed" });
+
+    await expect(analysisPromise).rejects.toThrow("Engine crashed");
+
+    await shutdownPool();
+  });
+
+  it("queues requests when all workers are busy and dispatches when one frees", async () => {
+    const { initPool, analyzePositionParallel, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(1);
+    emitReadyOnAll();
+    await initPromise;
+
+    const FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+    // Submit two requests to a pool of 1 — the second will be queued
+    const p1 = analyzePositionParallel(FEN, { depth: 12, multiPv: 1 });
+    const p2 = analyzePositionParallel(FEN, { depth: 12, multiPv: 1 });
+
+    const worker = mockWorkers[0]!;
+
+    // Resolve first request
+    worker._emit("message", { type: "result", lines: [makeResultLine(10)] });
+    const result1 = await p1;
+    expect(result1[0]!.score_cp).toBe(10);
+
+    // Now second request should be dispatched — resolve it
+    worker._emit("message", { type: "result", lines: [makeResultLine(20)] });
+    const result2 = await p2;
+    expect(result2[0]!.score_cp).toBe(20);
+
+    await shutdownPool();
+  });
+
+  it("uses both workers in parallel when pool size is 2", async () => {
+    const { initPool, analyzePositionParallel, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(2);
+    emitReadyOnAll();
+    await initPromise;
+
+    const FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+    const p1 = analyzePositionParallel(FEN, { depth: 12, multiPv: 1 });
+    const p2 = analyzePositionParallel(FEN, { depth: 12, multiPv: 1 });
+
+    // Both workers should have received a postMessage (both are busy now)
+    const w1 = mockWorkers[0]!;
+    const w2 = mockWorkers[1]!;
+    expect(w1.postMessage).toHaveBeenCalled();
+    expect(w2.postMessage).toHaveBeenCalled();
+
+    w1._emit("message", { type: "result", lines: [makeResultLine(5)] });
+    w2._emit("message", { type: "result", lines: [makeResultLine(15)] });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1[0]!.score_cp).toBe(5);
+    expect(r2[0]!.score_cp).toBe(15);
+
+    await shutdownPool();
+  });
+});
+
+describe("StockfishPool — shutdownPool", () => {
+  beforeEach(() => {
+    mockWorkers.length = 0;
+    vi.resetModules();
+  });
+
+  it("terminates all workers and resets state", async () => {
+    const { initPool, isPoolReady, shutdownPool } = await loadPool();
+
+    const initPromise = initPool(2);
+    emitReadyOnAll();
+    await initPromise;
+
+    expect(isPoolReady()).toBe(true);
+    await shutdownPool();
+    expect(isPoolReady()).toBe(false);
+  });
+});

--- a/mcp-server/src/engines/stockfish-pool.ts
+++ b/mcp-server/src/engines/stockfish-pool.ts
@@ -1,0 +1,238 @@
+/**
+ * stockfish-pool.ts
+ *
+ * A pool of N Stockfish Worker Threads for parallel position analysis.
+ * Each worker runs one analysis at a time; requests beyond current capacity
+ * are queued and dispatched when a worker becomes free.
+ *
+ * Public API:
+ *   initPool(size?)           — start N worker threads (default: 2)
+ *   analyzePositionParallel() — submit an analysis request to the pool
+ *   shutdownPool()            — terminate all workers
+ *   isPoolReady()             — true when at least one worker is available
+ */
+
+import { Worker } from "worker_threads";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { config } from "../config.js";
+import type { UCIAnalysisLine, StockfishOptions } from "../types/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_POOL_SIZE = 2;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface QueueEntry {
+  fen: string;
+  options: StockfishOptions;
+  resolve: (lines: UCIAnalysisLine[]) => void;
+  reject: (err: Error) => void;
+}
+
+type WorkerMessage =
+  | { type: "ready" }
+  | { type: "result"; lines: UCIAnalysisLine[] }
+  | { type: "error"; message: string };
+
+interface PoolWorker {
+  worker: Worker;
+  busy: boolean;
+  pending: QueueEntry | null;
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+const workers: PoolWorker[] = [];
+const queue: QueueEntry[] = [];
+let poolInitialized = false;
+
+// ---------------------------------------------------------------------------
+// Worker creation
+// ---------------------------------------------------------------------------
+
+function createPoolWorker(stockfishBinDir: string): Promise<PoolWorker> {
+  return new Promise<PoolWorker>((resolve, reject) => {
+    // Worker file is compiled to dist/engines/stockfish-worker.js
+    // At runtime __dirname is either src/ (tsx dev) or dist/ (compiled)
+    const workerPath = join(__dirname, "stockfish-worker.js");
+
+    const worker = new Worker(workerPath, {
+      workerData: {
+        stockfishBinDir,
+        timeout: config.stockfish.timeout,
+      },
+    });
+
+    const poolWorker: PoolWorker = {
+      worker,
+      busy: false,
+      pending: null,
+    };
+
+    let initialized = false;
+
+    const onMessage = (msg: WorkerMessage): void => {
+      if (!initialized) {
+        if (msg.type === "ready") {
+          initialized = true;
+          worker.on("message", onWorkerMessage.bind(null, poolWorker));
+          worker.off("message", onMessage);
+          resolve(poolWorker);
+        } else if (msg.type === "error") {
+          reject(new Error(`Worker failed to init: ${msg.message}`));
+        }
+        return;
+      }
+    };
+
+    worker.on("message", onMessage);
+
+    worker.on("error", (err) => {
+      if (!initialized) {
+        reject(err);
+        return;
+      }
+      // Worker crashed mid-analysis — reject the pending request
+      if (poolWorker.pending) {
+        const entry = poolWorker.pending;
+        poolWorker.pending = null;
+        poolWorker.busy = false;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        entry.reject(new Error(`Worker crashed: ${errMsg}`));
+        dispatchNext();
+      }
+    });
+
+    worker.on("exit", (code) => {
+      if (!initialized && code !== 0) {
+        reject(new Error(`Worker exited with code ${code} before ready`));
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Worker message handler (during normal operation, after init)
+// ---------------------------------------------------------------------------
+
+function onWorkerMessage(poolWorker: PoolWorker, msg: WorkerMessage): void {
+  const entry = poolWorker.pending;
+  if (!entry) return;
+
+  poolWorker.pending = null;
+  poolWorker.busy = false;
+
+  if (msg.type === "result") {
+    entry.resolve(msg.lines);
+  } else if (msg.type === "error") {
+    entry.reject(new Error(msg.message));
+  }
+
+  dispatchNext();
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch queue
+// ---------------------------------------------------------------------------
+
+function dispatchNext(): void {
+  if (queue.length === 0) return;
+
+  const freeWorker = workers.find((w) => !w.busy);
+  if (!freeWorker) return;
+
+  const entry = queue.shift();
+  if (!entry) return;
+
+  dispatch(freeWorker, entry);
+}
+
+function dispatch(poolWorker: PoolWorker, entry: QueueEntry): void {
+  poolWorker.busy = true;
+  poolWorker.pending = entry;
+  poolWorker.worker.postMessage({
+    type: "analyze",
+    fen: entry.fen,
+    depth: entry.options.depth,
+    multiPv: entry.options.multiPv,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function initPool(size: number = DEFAULT_POOL_SIZE): Promise<void> {
+  if (poolInitialized) return;
+
+  const stockfishBinDir = join(__dirname, "../../node_modules/stockfish/bin");
+
+  const results = await Promise.allSettled(
+    Array.from({ length: size }, () => createPoolWorker(stockfishBinDir))
+  );
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      workers.push(result.value);
+    } else {
+      console.error(
+        `[StockfishPool] Worker failed to start: ${(result.reason as Error).message}`
+      );
+    }
+  }
+
+  if (workers.length === 0) {
+    throw new Error("StockfishPool: all workers failed to start");
+  }
+
+  poolInitialized = true;
+  console.error(
+    `[StockfishPool] Initialized ${workers.length}/${size} workers`
+  );
+}
+
+export function isPoolReady(): boolean {
+  return poolInitialized && workers.length > 0;
+}
+
+export async function analyzePositionParallel(
+  fen: string,
+  options?: Partial<StockfishOptions>
+): Promise<UCIAnalysisLine[]> {
+  const opts: StockfishOptions = {
+    depth: options?.depth ?? config.stockfish.quietDepth,
+    multiPv: options?.multiPv ?? 1,
+  };
+
+  return new Promise<UCIAnalysisLine[]>((resolve, reject) => {
+    const entry: QueueEntry = { fen, options: opts, resolve, reject };
+
+    const freeWorker = workers.find((w) => !w.busy);
+    if (freeWorker) {
+      dispatch(freeWorker, entry);
+    } else {
+      queue.push(entry);
+    }
+  });
+}
+
+export async function shutdownPool(): Promise<void> {
+  for (const pw of workers) {
+    pw.worker.postMessage({ type: "shutdown" });
+  }
+  await Promise.allSettled(workers.map((pw) => pw.worker.terminate()));
+  workers.length = 0;
+  queue.length = 0;
+  poolInitialized = false;
+  console.error("[StockfishPool] Shutdown complete");
+}

--- a/mcp-server/src/engines/stockfish-worker.ts
+++ b/mcp-server/src/engines/stockfish-worker.ts
@@ -1,0 +1,248 @@
+/**
+ * stockfish-worker.ts
+ *
+ * Worker Thread entry point for Stockfish analysis.
+ * Runs inside a Node.js Worker Thread; communicates with the pool via MessagePort.
+ *
+ * Protocol (messages received from parent):
+ *   { type: 'analyze', fen: string, depth: number, multiPv: number }
+ *   { type: 'shutdown' }
+ *
+ * Protocol (messages sent to parent):
+ *   { type: 'ready' }
+ *   { type: 'result', lines: UCIAnalysisLine[] }
+ *   { type: 'error', message: string }
+ */
+
+import { workerData, parentPort } from "worker_threads";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import type { UCIAnalysisLine } from "../types/index.js";
+
+if (!parentPort) {
+  throw new Error("stockfish-worker must be run as a Worker Thread");
+}
+
+const port = parentPort;
+
+// ---------------------------------------------------------------------------
+// Worker config (passed via workerData)
+// ---------------------------------------------------------------------------
+
+interface WorkerData {
+  stockfishBinDir: string;
+  timeout: number;
+}
+
+const { stockfishBinDir, timeout } = workerData as WorkerData;
+
+// ---------------------------------------------------------------------------
+// Types for the raw stockfish.js instance
+// ---------------------------------------------------------------------------
+
+interface StockfishInstance {
+  addMessageListener(handler: (line: string) => void): void;
+  postMessage(cmd: string): void;
+}
+
+// ---------------------------------------------------------------------------
+// UCI output parser (same logic as stockfish.ts)
+// ---------------------------------------------------------------------------
+
+function parseInfoLine(line: string): {
+  rank: number;
+  depth: number;
+  score_cp: number | null;
+  score_mate: number | null;
+  pv: string[];
+} | null {
+  if (!line.startsWith("info ") || !line.includes(" pv ")) return null;
+
+  const depthMatch = line.match(/\bdepth (\d+)/);
+  const mpvMatch = line.match(/\bmultipv (\d+)/);
+  const cpMatch = line.match(/\bscore cp (-?\d+)/);
+  const mateMatch = line.match(/\bscore mate (-?\d+)/);
+  const pvMatch = line.match(/ pv (.+)$/);
+
+  if (!depthMatch || !pvMatch) return null;
+
+  const depth = parseInt(depthMatch[1] ?? "0");
+  const rank = mpvMatch ? parseInt(mpvMatch[1] ?? "1") : 1;
+  const score_cp = cpMatch ? parseInt(cpMatch[1] ?? "0") : null;
+  const score_mate = mateMatch ? parseInt(mateMatch[1] ?? "0") : null;
+  const pv = (pvMatch[1] ?? "").trim().split(/\s+/);
+
+  return { rank, depth, score_cp, score_mate, pv };
+}
+
+// ---------------------------------------------------------------------------
+// Engine state
+// ---------------------------------------------------------------------------
+
+interface PendingAnalysis {
+  depth: number;
+  lines: Map<number, UCIAnalysisLine>;
+  resolve: (lines: UCIAnalysisLine[]) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+let engine: StockfishInstance | null = null;
+let engineReady = false;
+let pending: PendingAnalysis | null = null;
+
+// ---------------------------------------------------------------------------
+// Message handler from Stockfish engine
+// ---------------------------------------------------------------------------
+
+function onEngineMessage(line: string): void {
+  if (line === "uciok" || line.startsWith("id ") || line.startsWith("option ")) {
+    return;
+  }
+
+  if (line === "readyok") {
+    engineReady = true;
+    port.postMessage({ type: "ready" });
+    return;
+  }
+
+  if (!pending) return;
+
+  if (line.startsWith("info ") && line.includes(" pv ")) {
+    const parsed = parseInfoLine(line);
+    if (parsed && parsed.depth === pending.depth) {
+      pending.lines.set(parsed.rank, {
+        depth: parsed.depth,
+        score_cp: parsed.score_cp,
+        score_mate: parsed.score_mate,
+        pv: parsed.pv,
+        multipv_rank: parsed.rank,
+      });
+    }
+    return;
+  }
+
+  if (line.startsWith("bestmove")) {
+    clearTimeout(pending.timer);
+    const results = Array.from(pending.lines.values()).sort(
+      (a, b) => a.multipv_rank - b.multipv_rank
+    );
+    const resolve = pending.resolve;
+    pending = null;
+    resolve(results);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run one analysis request
+// ---------------------------------------------------------------------------
+
+function runAnalysis(
+  fen: string,
+  depth: number,
+  multiPv: number
+): Promise<UCIAnalysisLine[]> {
+  return new Promise<UCIAnalysisLine[]>((resolve, reject) => {
+    if (!engine || !engineReady) {
+      reject(new Error("Engine not ready"));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (pending) {
+        engine?.postMessage("stop");
+        const err = new Error(`Stockfish worker timeout after ${timeout}ms`);
+        const r = pending.reject;
+        pending = null;
+        r(err);
+      }
+    }, timeout);
+
+    pending = {
+      depth,
+      lines: new Map(),
+      resolve,
+      reject,
+      timer,
+    };
+
+    engine.postMessage(`setoption name MultiPV value ${multiPv}`);
+    engine.postMessage(`position fen ${fen}`);
+    engine.postMessage(`go depth ${depth}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Initialize engine
+// ---------------------------------------------------------------------------
+
+async function init(): Promise<void> {
+  const sfPath = join(stockfishBinDir, "stockfish-18-single.js");
+  const wasmPath = join(stockfishBinDir, "stockfish-18-single.wasm");
+
+  const require = createRequire(import.meta.url);
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const InitEngine = require(sfPath) as () => (mod: {
+    locateFile: (path: string) => string;
+  }) => Promise<StockfishInstance>;
+
+  engine = await InitEngine()({
+    locateFile: (path: string) => {
+      if (path.endsWith(".wasm")) return wasmPath;
+      return path;
+    },
+  });
+
+  engine.addMessageListener(onEngineMessage);
+  engine.postMessage("uci");
+  engine.postMessage("isready");
+
+  // Wait for readyok (signalled by setting engineReady = true and posting 'ready')
+  await new Promise<void>((resolve) => {
+    const interval = setInterval(() => {
+      if (engineReady) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 50);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Message handler from parent (pool)
+// ---------------------------------------------------------------------------
+
+port.on("message", async (msg: unknown) => {
+  if (!msg || typeof msg !== "object") return;
+  const message = msg as Record<string, unknown>;
+
+  if (message["type"] === "shutdown") {
+    engine?.postMessage("quit");
+    process.exit(0);
+  }
+
+  if (message["type"] === "analyze") {
+    const fen = message["fen"] as string;
+    const depth = message["depth"] as number;
+    const multiPv = message["multiPv"] as number;
+
+    try {
+      const lines = await runAnalysis(fen, depth, multiPv);
+      port.postMessage({ type: "result", lines });
+    } catch (err: unknown) {
+      const message_ = err instanceof Error ? err.message : String(err);
+      port.postMessage({ type: "error", message: message_ });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+init().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[StockfishWorker] Failed to init engine: ${msg}`);
+  port.postMessage({ type: "error", message: `Worker init failed: ${msg}` });
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { initEngine, shutdown } from "./engines/stockfish.js";
+import { initPool, shutdownPool } from "./engines/stockfish-pool.js";
 import { handleAnalyzePosition } from "./tools/analyze-position.js";
 import { handleAnalyzeGame } from "./tools/analyze-game.js";
 import { handleGetPlayerStats } from "./tools/get-player-stats.js";
@@ -118,24 +119,28 @@ async function main(): Promise<void> {
 
   // Initialize Stockfish after the MCP handshake so we don't block the
   // initialize request (WASM load can take 30-60s on first run).
-  console.error("[ChessContext] Initializing Stockfish engine...");
-  initEngine()
-    .then(() => console.error("[ChessContext] Stockfish engine ready."))
-    .catch((err: unknown) => console.error("[ChessContext] Stockfish init failed:", err));
+  console.error("[ChessContext] Initializing Stockfish engine and worker pool...");
+  Promise.all([
+    initEngine()
+      .then(() => console.error("[ChessContext] Stockfish single-thread engine ready."))
+      .catch((err: unknown) => console.error("[ChessContext] Stockfish init failed:", err)),
+    initPool()
+      .then(() => console.error("[ChessContext] Stockfish worker pool ready."))
+      .catch((err: unknown) => console.error("[ChessContext] Stockfish pool init failed:", err)),
+  ]).catch(() => {
+    // Individual errors are already logged above
+  });
 }
 
 // Graceful shutdown
-process.on("SIGTERM", async () => {
+async function gracefulShutdown(): Promise<void> {
   console.error("[ChessContext] Shutting down...");
-  await shutdown();
+  await Promise.allSettled([shutdown(), shutdownPool()]);
   process.exit(0);
-});
+}
 
-process.on("SIGINT", async () => {
-  console.error("[ChessContext] Shutting down...");
-  await shutdown();
-  process.exit(0);
-});
+process.on("SIGTERM", () => { void gracefulShutdown(); });
+process.on("SIGINT", () => { void gracefulShutdown(); });
 
 main().catch((err: unknown) => {
   console.error("[ChessContext] Fatal error:", err);

--- a/mcp-server/src/tools/analyze-game.ts
+++ b/mcp-server/src/tools/analyze-game.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { Chess } from "chess.js";
 import { analyzePosition as stockfishAnalyze, isReady as stockfishReady, waitUntilReady } from "../engines/stockfish.js";
+import { analyzePositionParallel, isPoolReady } from "../engines/stockfish-pool.js";
 import { getCloudEval } from "../engines/lichess-eval.js";
 import { getPositionEval, setPositionEval, positionCacheKey } from "../cache/index.js";
 import {
@@ -222,22 +223,54 @@ async function runAnalysis(input: AnalyzeGameInput): Promise<GameAnalysis> {
     batchResults.forEach((r, j) => { cloudResults[i + j] = r; });
   }
 
-  // Phase 2: sequential Stockfish only for cloud-eval misses, at quiet depth
+  // Phase 2: parallel Stockfish fallback for cloud-eval misses, at quiet depth.
+  // Use the worker pool when available (parallel), otherwise fall back to the
+  // single-threaded engine (sequential) so the path still works during warmup.
   const quietDepth = config.stockfish.quietDepth;
   const evals: number[] = new Array(positions.length).fill(0);
   const bestMoves: string[] = new Array(positions.length).fill("");
   let evalsCovered = 0;
 
+  // Identify positions that need Stockfish
+  const missIndices: number[] = [];
   for (let i = 0; i < positions.length; i++) {
-    const pos = positions[i]!;
-    let lines = cloudResults[i];
-
+    const lines = cloudResults[i];
     if (!lines || lines.length === 0) {
-      if (stockfishReady()) {
-        lines = await stockfishAnalyze(pos.fen, { depth: quietDepth, multiPv: 1 }).catch(() => []);
-      }
+      missIndices.push(i);
     }
+  }
 
+  // Analyse all misses in parallel when the pool is ready
+  if (missIndices.length > 0) {
+    const usePool = isPoolReady();
+    const useSequential = !usePool && stockfishReady();
+
+    const analysisPromises = missIndices.map((i) => {
+      const pos = positions[i]!;
+      if (usePool) {
+        return analyzePositionParallel(pos.fen, { depth: quietDepth, multiPv: 1 }).catch(
+          (): UCIAnalysisLine[] => []
+        );
+      }
+      if (useSequential) {
+        return stockfishAnalyze(pos.fen, { depth: quietDepth, multiPv: 1 }).catch(
+          (): UCIAnalysisLine[] => []
+        );
+      }
+      return Promise.resolve<UCIAnalysisLine[]>([]);
+    });
+
+    const missResults = await Promise.all(analysisPromises);
+
+    for (let j = 0; j < missIndices.length; j++) {
+      const i = missIndices[j]!;
+      cloudResults[i] = missResults[j] ?? [];
+    }
+  }
+
+  // Merge cloud + Stockfish results into evals / bestMoves arrays
+  for (let i = 0; i < positions.length; i++) {
+    const lines = cloudResults[i];
     if (lines && lines.length > 0) {
       const line = lines[0]!;
       evals[i] = lineToEvalCp(line);


### PR DESCRIPTION
## What
Closes #2

Replaces the sequential Stockfish fallback in `analyze_game` with a parallel Worker Thread pool. An 80-position game with all cloud-eval misses now runs in ~N/pool_size× the time instead of sequentially.

## Spike findings
Multi-threaded WASM (`stockfish-18.js`) is **not needed**. Running N copies of the single-threaded build (`stockfish-18-single.js`) inside separate `worker_threads` Workers achieves the same throughput gain without any `SharedArrayBuffer` / COOP-COEP complexity. Node 20 `worker_threads` works cleanly with ESM and `import.meta.url`.

## Architecture

```
index.ts
  └─ initPool(2)          ← fire-and-forget after MCP handshake
       └─ Worker × 2
            └─ stockfish-worker.ts   (UCI wrapper, single WASM per worker)

analyze-game.ts (Phase 2 fallback)
  missIndices → Promise.all(analyzePositionParallel × N)
             ↘ falls back to sequential stockfishAnalyze if pool not ready
```

### New files
| File | Purpose |
|------|---------|
| `engines/stockfish-worker.ts` | Worker Thread entry; UCI wrapper; protocol: `{type:'analyze'\|'shutdown'}` in, `{type:'ready'\|'result'\|'error'}` out |
| `engines/stockfish-pool.ts` | Pool of N workers; queue + dispatch; `initPool()`, `analyzePositionParallel()`, `shutdownPool()`, `isPoolReady()` |
| `engines/stockfish-pool.test.ts` | Unit tests with fully mocked `worker_threads.Worker` |

### Changed files
| File | Change |
|------|--------|
| `tools/analyze-game.ts` | Phase 2: collect all miss indices → `Promise.all(analyzePositionParallel)` when pool ready, sequential fallback otherwise |
| `index.ts` | Launch `initPool()` alongside `initEngine()`; `gracefulShutdown()` calls both `shutdown()` + `shutdownPool()` |

## Test plan
- [x] `npm run build` — zero TypeScript errors
- [x] `npm test` — 158 tests pass across 11 files
- [ ] Manual: connect Claude Desktop, analyze a lower-rated game with many cloud-eval misses — should complete in <20s
- [ ] Manual: verify `[StockfishPool] Initialized 2/2 workers` appears in stderr ~60s after startup