### PR TITLE
feat: explain_move tool — single-move explanation with board artifact

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,14 @@
       Free, offline-capable once game data is fetched.
       → [#18](https://github.com/rutvij26/chess-context/issues/18)
 
-### v1.0 — Advanced Player Tools
+### v1.0 — ELO Climber _(public release, rich artifact output)_
+Theme: every tool asks "how does this help me climb?". Targets public release with clean onboarding.
+All position-returning tools include a `boardData` artifact payload for interactive SVG board rendering.
+
+#### Fix first
+- [ ] **BUG** `analyze_game` eval POV not normalized → [#85](https://github.com/rutvij26/chess-context/issues/85)
+
+#### New tools
 - [ ] `get_endgame_analysis` — Syzygy tablebase via Lichess free API (≤7 pieces):
       win/draw/loss verdict + human-readable winning plan → [#19](https://github.com/rutvij26/chess-context/issues/19)
 - [ ] `detect_tilt` — identify tilt indicators from recent game patterns:
@@ -82,6 +89,22 @@
       whether the novelty was an improvement or a mistake → [#23](https://github.com/rutvij26/chess-context/issues/23)
 - [ ] `compare_games` — surface what changed between two games by the same player
       (useful for "did my opening improve after studying this line?") → [#24](https://github.com/rutvij26/chess-context/issues/24)
+- [ ] `explain_move` — given any game (PGN / chess.com URL / lichess URL / username) + move
+      number, explain why the move was played, what the best alternative was, and what to
+      remember → [#87](https://github.com/rutvij26/chess-context/issues/87)
+- [ ] `get_improvement_tracker` — week-over-week accuracy, blunder rate trend, ELO trajectory
+      with plain-English narrative → [#92](https://github.com/rutvij26/chess-context/issues/92)
+- [ ] `get_coach` — context-aware improvement advisor with `frequency: daily | weekly | monthly`.
+      Pre-game advisor + post-session debrief + structured study plan, all in one tool.
+      → [#88](https://github.com/rutvij26/chess-context/issues/88)
+- [ ] `reanalyze_games` — bulk re-run Stockfish analysis on stored games; useful after engine
+      upgrades or to fill coverage gaps → [#89](https://github.com/rutvij26/chess-context/issues/89)
+
+#### Infrastructure
+- [ ] `refresh_games` bulk sync — date-range params, incremental mode, 200+ game support,
+      fix `fetchGameByUrl` 50-game cap → [#90](https://github.com/rutvij26/chess-context/issues/90)
+- [ ] Board artifact standard — all position tools return `boardData` (FENs, arrows, classifications,
+      annotations) so Claude renders self-contained interactive SVG board artifacts → [#91](https://github.com/rutvij26/chess-context/issues/91)
 
 ### v2.0 — Advanced / Self-Hosting
 - [ ] Docker Compose deployment with native Stockfish + Leela Chess Zero → [#25](https://github.com/rutvij26/chess-context/issues/25)

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,6 +16,7 @@ import { handleGetAnalysisProgress } from "./tools/get-analysis-progress.js";
 import { handleGetOpeningTheory } from "./tools/get-opening-theory.js";
 import { handleFindOpeningGaps } from "./tools/find-opening-gaps.js";
 import { handleGeneratePuzzles } from "./tools/generate-puzzles.js";
+import { handleExplainMove } from "./tools/explain-move.js";
 import {
   AnalyzePositionInputSchema,
   AnalyzeGameInputSchema,
@@ -29,6 +30,7 @@ import {
   GetOpeningTheoryInputSchema,
   FindOpeningGapsInputSchema,
   GeneratePuzzlesInputSchema,
+  ExplainMoveInputSchema,
 } from "./types/index.js";
 
 // ---------------------------------------------------------------------------
@@ -253,6 +255,26 @@ server.registerTool(
   },
   async (input) => {
     const result = await handleGeneratePuzzles(input);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.registerTool(
+  "explain_move",
+  {
+    title: "Explain Move",
+    description:
+      "Given a chess game and a move number, explains why the move was played, " +
+      "whether it was the best move, what the engine recommends instead, and what the player should learn. " +
+      "Accepts PGN text, chess.com game URL, lichess game URL, or username (uses their most recent game). " +
+      "Returns classification (best/good/inaccuracy/mistake/blunder), move intent, best alternative with explanation, " +
+      "actionable takeaway, and a boardData payload for interactive board rendering.",
+    inputSchema: ExplainMoveInputSchema,
+  },
+  async (input) => {
+    const result = await handleExplainMove(input);
     return {
       content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
     };

--- a/mcp-server/src/intelligence/critical-moments.ts
+++ b/mcp-server/src/intelligence/critical-moments.ts
@@ -25,11 +25,11 @@ export interface MoveRecord {
  * White's eval is positive when white is better.
  * Black's eval: we need to flip the sign when it's black's turn.
  */
-function evalForSideToMove(evalCp: number, color: "white" | "black"): number {
+export function evalForSideToMove(evalCp: number, color: "white" | "black"): number {
   return color === "white" ? evalCp : -evalCp;
 }
 
-function categorise(evalDropCp: number, hadWinning: boolean, isNowLosing: boolean): MoveCategory {
+export function categorise(evalDropCp: number, hadWinning: boolean, isNowLosing: boolean): MoveCategory {
   if (hadWinning && isNowLosing) return "missed_win";
   if (evalDropCp >= config.analysis.blunderThreshold) return "blunder";
   if (evalDropCp >= config.analysis.mistakeThreshold) return "mistake";

--- a/mcp-server/src/tools/analyze-game.ts
+++ b/mcp-server/src/tools/analyze-game.ts
@@ -24,7 +24,7 @@ type ProgressCallback = (completed: number, total: number) => void;
 // PGN / URL resolution
 // ---------------------------------------------------------------------------
 
-async function resolvePgn(input: AnalyzeGameInput): Promise<string> {
+export async function resolvePgn(input: AnalyzeGameInput): Promise<string> {
   // 1. Raw PGN provided directly
   if (input.pgn) return input.pgn;
 
@@ -80,7 +80,7 @@ async function resolvePgn(input: AnalyzeGameInput): Promise<string> {
 // PGN header parsing
 // ---------------------------------------------------------------------------
 
-function extractHeader(pgn: string, tag: string): string {
+export function extractHeader(pgn: string, tag: string): string {
   const match = pgn.match(new RegExp(`\\[${tag} "([^"]+)"\\]`));
   return match?.[1] ?? "Unknown";
 }
@@ -90,7 +90,7 @@ function extractHeader(pgn: string, tag: string): string {
 // ---------------------------------------------------------------------------
 
 
-function lineToEvalCp(line: UCIAnalysisLine): number {
+export function lineToEvalCp(line: UCIAnalysisLine): number {
   if (line.score_mate !== null) {
     return line.score_mate > 0 ? 10000 : -10000;
   }

--- a/mcp-server/src/tools/analyze-position.ts
+++ b/mcp-server/src/tools/analyze-position.ts
@@ -23,7 +23,7 @@ import type {
  * Convert a UCI move (e.g. "e2e4") to SAN notation using chess.js.
  * Returns the UCI move if conversion fails.
  */
-function uciToSan(board: Chess, uciMove: string): string {
+export function uciToSan(board: Chess, uciMove: string): string {
   try {
     const from = uciMove.slice(0, 2);
     const to = uciMove.slice(2, 4);
@@ -45,7 +45,7 @@ function uciToSan(board: Chess, uciMove: string): string {
  * Convert a PV (array of UCI moves) to SAN notation.
  * Returns the first 4 moves as SAN.
  */
-function pvToSan(board: Chess, pv: string[]): string[] {
+export function pvToSan(board: Chess, pv: string[]): string[] {
   const clone = new Chess(board.fen());
   const sans: string[] = [];
 

--- a/mcp-server/src/tools/explain-move.test.ts
+++ b/mcp-server/src/tools/explain-move.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleExplainMove } from "./explain-move.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../engines/engine-router.js", () => ({
+  waitUntilRouterReady: vi.fn().mockResolvedValue(undefined),
+  getEval: vi.fn(),
+}));
+
+vi.mock("../data/chesscom-api.js", () => ({
+  getStats: vi.fn(),
+  fetchLastGame: vi.fn(),
+  fetchGameByUrl: vi.fn(),
+}));
+
+vi.mock("../data/lichess-api.js", () => ({
+  getProfile: vi.fn(),
+  getRecentGames: vi.fn(),
+}));
+
+import { getEval } from "../engines/engine-router.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+// Scholar's mate game — white plays 4.Qh5# (blunder for black at move 4)
+const SCHOLARS_MATE_PGN = `[Event "Test"]
+[White "Alice"]
+[Black "Bob"]
+[Result "1-0"]
+[WhiteElo "1200"]
+[BlackElo "1000"]
+
+1. e4 e5 2. Bc4 Nc6 3. Qh5 Nf6?? 4. Qxf7# 1-0`;
+
+// Simple 5-move game
+const SHORT_PGN = `[Event "Test"]
+[White "Alice"]
+[Black "Bob"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 *`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockEval(lines: Array<{ score_cp: number | null; score_mate: number | null; pv: string[] }>) {
+  return lines.map((l, i) => ({
+    depth: 18,
+    score_cp: l.score_cp,
+    score_mate: l.score_mate,
+    pv: l.pv,
+    multipv_rank: i + 1,
+  }));
+}
+
+const EQUAL_EVAL = mockEval([{ score_cp: 0, score_mate: null, pv: ["e2e4"] }]);
+const BEST_MOVE_E4 = mockEval([
+  { score_cp: 20, score_mate: null, pv: ["e2e4", "e7e5"] },
+  { score_cp: 15, score_mate: null, pv: ["d2d4", "d7d5"] },
+  { score_cp: 10, score_mate: null, pv: ["g1f3", "d7d5"] },
+]);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleExplainMove", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when no game source is provided", async () => {
+    await expect(
+      handleExplainMove({ move_number: 1, color: "white" })
+    ).rejects.toThrow(/game source/i);
+  });
+
+  it("throws when move number is out of range", async () => {
+    vi.mocked(getEval).mockResolvedValue(EQUAL_EVAL);
+    await expect(
+      handleExplainMove({ move_number: 25, color: "white", pgn: SHORT_PGN })
+    ).rejects.toThrow(/out of range/i);
+  });
+
+  it("classifies best move correctly", async () => {
+    // e2e4 is the played move AND the best move
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(BEST_MOVE_E4) // linesBefore (multiPv=3)
+      .mockResolvedValueOnce(EQUAL_EVAL);  // linesAfter
+
+    const result = await handleExplainMove({
+      move_number: 1,
+      color: "white",
+      pgn: SHORT_PGN,
+    });
+
+    expect(result.classification).toBe("best");
+    expect(result.best_move).toBeNull();
+    expect(result.eval_drop_cp).toBe(0);
+    expect(result.move_played).toBe("e4");
+  });
+
+  it("classifies blunder correctly with best alternative", async () => {
+    // Black plays Nf6?? at move 3 in Scholar's mate — engine recommends something else
+    const engineBefore = mockEval([
+      { score_cp: 300, score_mate: null, pv: ["e7e6", "d1h5"] }, // not Nf6
+      { score_cp: 200, score_mate: null, pv: ["d7d6", "d1h5"] },
+    ]);
+    // score_cp is always from White's perspective — after Nf6??, White is winning (+600)
+    const engineAfter = mockEval([
+      { score_cp: 600, score_mate: null, pv: ["d1f7"] },
+    ]);
+
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(engineBefore)
+      .mockResolvedValueOnce(engineAfter);
+
+    const result = await handleExplainMove({
+      move_number: 3,
+      color: "black",
+      pgn: SCHOLARS_MATE_PGN,
+    });
+
+    expect(result.classification).toBe("blunder");
+    expect(result.eval_drop_cp).toBeGreaterThanOrEqual(300);
+    expect(result.best_move).not.toBeNull();
+    expect(result.best_move?.san).toBeTruthy();
+  });
+
+  it("normalizes eval drop from black's perspective", async () => {
+    // White's eval before: +100 (white slightly better)
+    // After black's move: +50 (still white better, so black improved — eval DROP is negative from white POV)
+    // From black's perspective: before=-100, after=-50, drop = -100 - (-50) = -50 → clamp to 0
+    const before = mockEval([{ score_cp: 100, score_mate: null, pv: ["e7e5"] }]);
+    const after  = mockEval([{ score_cp: 50,  score_mate: null, pv: ["e2e4"] }]);
+
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(before)
+      .mockResolvedValueOnce(after);
+
+    const result = await handleExplainMove({
+      move_number: 1,
+      color: "black",
+      pgn: SHORT_PGN,
+    });
+
+    // From black's perspective: before_stm = -100, after_stm = -50
+    // drop = max(0, -100 - (-50)) = max(0, -50) = 0
+    expect(result.eval_drop_cp).toBe(0);
+  });
+
+  it("returns non-null boardData with correct arrows", async () => {
+    const engineBefore = mockEval([
+      { score_cp: 50, score_mate: null, pv: ["d2d4", "d7d5"] }, // engine wants d4
+      { score_cp: 30, score_mate: null, pv: ["g1f3", "e7e5"] },
+    ]);
+    const engineAfter = mockEval([
+      { score_cp: -10, score_mate: null, pv: ["e7e5"] },
+    ]);
+
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(engineBefore)
+      .mockResolvedValueOnce(engineAfter);
+
+    const result = await handleExplainMove({
+      move_number: 1,
+      color: "white",
+      pgn: SHORT_PGN,
+    });
+
+    expect(result.board_data).not.toBeNull();
+    const targetMove = result.board_data!.moves.find((m) => m.ply === 1);
+    expect(targetMove).toBeDefined();
+    expect(targetMove!.arrows.length).toBeGreaterThanOrEqual(1);
+    // played move arrow (e2e4 was played, d2d4 is best — two arrows)
+    expect(targetMove!.arrows.length).toBe(2);
+    const bestArrow = targetMove!.arrows.find((a) => a.label === "Best");
+    expect(bestArrow).toBeDefined();
+    expect(bestArrow!.color).toBe("#4caf50");
+  });
+
+  it("adapts player level: beginner gets simpler language", async () => {
+    const engineBefore = mockEval([
+      { score_cp: 200, score_mate: null, pv: ["d2d4"] },
+    ]);
+    const engineAfter = mockEval([
+      { score_cp: -150, score_mate: null, pv: ["e7e5"] },
+    ]);
+
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(engineBefore)
+      .mockResolvedValueOnce(engineAfter);
+
+    const beginner = await handleExplainMove({
+      move_number: 1,
+      color: "white",
+      pgn: SHORT_PGN,
+      player_level: "beginner",
+    });
+
+    vi.mocked(getEval)
+      .mockResolvedValueOnce(engineBefore)
+      .mockResolvedValueOnce(engineAfter);
+
+    const advanced = await handleExplainMove({
+      move_number: 1,
+      color: "white",
+      pgn: SHORT_PGN,
+      player_level: "advanced",
+    });
+
+    // Both should have a classification
+    expect(beginner.player_level).toBe("beginner");
+    expect(advanced.player_level).toBe("advanced");
+    // Advanced should mention cp values
+    expect(advanced.assessment).toMatch(/pawn/i);
+  });
+
+  it("identifies castling move intent", async () => {
+    const castlingPgn = `[Event "Test"]
+[White "Alice"]
+[Black "Bob"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. O-O *`;
+
+    vi.mocked(getEval)
+      .mockResolvedValue(
+        mockEval([{ score_cp: 30, score_mate: null, pv: ["e1g1"] }])
+      );
+
+    const result = await handleExplainMove({
+      move_number: 4,
+      color: "white",
+      pgn: castlingPgn,
+    });
+
+    expect(result.move_played).toBe("O-O");
+    expect(result.move_intent.toLowerCase()).toMatch(/castle|king safety/i);
+  });
+});

--- a/mcp-server/src/tools/explain-move.ts
+++ b/mcp-server/src/tools/explain-move.ts
@@ -1,0 +1,723 @@
+import { Chess } from "chess.js";
+import { config } from "../config.js";
+import { getEval, waitUntilRouterReady } from "../engines/engine-router.js";
+import {
+  evalForSideToMove,
+  categorise,
+} from "../intelligence/critical-moments.js";
+import {
+  classifyPhase,
+  classifyPawnStructure,
+  getMaterialBalance,
+} from "../intelligence/position-classifier.js";
+import { tagThemes } from "../intelligence/theme-tagger.js";
+import { generateNarrative } from "../intelligence/narrative-generator.js";
+import { detectPlayerLevel } from "../intelligence/player-level.js";
+import { getStats as getChessComStats } from "../data/chesscom-api.js";
+import { getProfile as getLichessProfile } from "../data/lichess-api.js";
+import {
+  resolvePgn,
+  extractHeader,
+  lineToEvalCp,
+} from "./analyze-game.js";
+import { uciToSan, pvToSan } from "./analyze-position.js";
+import type {
+  ExplainMoveInput,
+  MoveExplanation,
+  BoardData,
+  BoardMove,
+  BoardArrow,
+  GamePhase,
+  ChessTheme,
+  PawnStructure,
+} from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Arrow color by classification
+// ---------------------------------------------------------------------------
+
+function classToColor(
+  classification: MoveExplanation["classification"]
+): string {
+  switch (classification) {
+    case "best":
+      return "#4caf50";
+    case "good":
+    case "excellent":
+      return "#8bc34a";
+    case "inaccuracy":
+      return "#ffeb3b";
+    case "mistake":
+      return "#ff9800";
+    case "blunder":
+    case "missed_win":
+    case "miss":
+      return "#f44336";
+    default:
+      return "#4caf50";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Move intent builder
+// ---------------------------------------------------------------------------
+
+interface VerboseMove {
+  from: string;
+  to: string;
+  flags: string;
+  piece: string;
+  captured?: string;
+  promotion?: string;
+  san: string;
+}
+
+function buildMoveIntent(
+  playedMove: VerboseMove,
+  themes: ChessTheme[],
+  phase: GamePhase,
+  level: "beginner" | "club" | "advanced"
+): string {
+  const themeSet = new Set(themes);
+  const piece = playedMove.piece.toUpperCase();
+  const flags = playedMove.flags;
+
+  // Castling
+  if (flags.includes("k") || flags.includes("q")) {
+    return "Castles to improve king safety and connect the rooks.";
+  }
+
+  // Promotion
+  if (flags.includes("p") && playedMove.promotion) {
+    const promPiece = playedMove.promotion.toUpperCase();
+    return `Promotes the pawn to a ${promPiece === "Q" ? "queen" : promPiece === "R" ? "rook" : promPiece === "B" ? "bishop" : "knight"}, gaining a powerful piece.`;
+  }
+
+  const parts: string[] = [];
+
+  // Capture
+  if (flags.includes("c") || flags.includes("e")) {
+    const captured = playedMove.captured?.toUpperCase() ?? "piece";
+    const capturedName =
+      captured === "Q" ? "queen" :
+      captured === "R" ? "rook" :
+      captured === "B" ? "bishop" :
+      captured === "N" ? "knight" :
+      captured === "P" ? "pawn" : "piece";
+    parts.push(`Captures the ${capturedName} on ${playedMove.to}`);
+  }
+
+  // Check
+  if (flags.includes("+") || playedMove.san?.endsWith("+")) {
+    parts.push("giving check");
+  }
+
+  // Development (opening phase, piece moving from back rank)
+  if (phase === "opening" && (piece === "N" || piece === "B")) {
+    if (["1", "8"].some((r) => playedMove.from.endsWith(r))) {
+      const pieceName = piece === "N" ? "knight" : "bishop";
+      parts.push(`Develops the ${pieceName} toward the center`);
+    }
+  }
+
+  // Thematic cross-references
+  if (parts.length === 0) {
+    if (piece === "K" || piece === "Q" || piece === "R") {
+      const pieceName =
+        piece === "K" ? "king" : piece === "Q" ? "queen" : "rook";
+      parts.push(`Moves the ${pieceName} to ${playedMove.to}`);
+    } else if (piece === "P") {
+      parts.push(`Advances the pawn to ${playedMove.to}`);
+    } else {
+      parts.push(`Moves to ${playedMove.to}`);
+    }
+  }
+
+  if (themeSet.has("fork_potential") && (piece === "N" || piece === "Q")) {
+    parts.push("creating a fork threat");
+  }
+  if (themeSet.has("king_safety") && phase !== "endgame") {
+    parts.push("while keeping an eye on king safety");
+  }
+  if (themeSet.has("open_file") && piece === "R") {
+    parts.push("seizing the open file");
+  }
+  if (themeSet.has("back_rank") && (piece === "R" || piece === "Q")) {
+    parts.push("targeting back-rank weaknesses");
+  }
+
+  // level is used only for future expansion — suppress unused warning
+  void level;
+
+  return parts.join(", ") + ".";
+}
+
+// ---------------------------------------------------------------------------
+// Assessment builder
+// ---------------------------------------------------------------------------
+
+function buildAssessment(
+  classification: MoveExplanation["classification"],
+  evalDropCp: number,
+  playedSan: string,
+  bestSan: string,
+  level: "beginner" | "club" | "advanced"
+): string {
+  const pawns = (evalDropCp / 100).toFixed(1);
+  switch (classification) {
+    case "best":
+      return "This was the best move in the position.";
+    case "excellent":
+    case "good":
+      return level === "advanced"
+        ? `A good move — only ${pawns} pawns below the engine's top choice.`
+        : "A good move, very close to the engine's top choice.";
+    case "inaccuracy":
+      return level === "beginner"
+        ? `A slight inaccuracy. ${bestSan} was a bit more accurate.`
+        : `A slight inaccuracy (−${pawns} pawns). ${bestSan} was more precise.`;
+    case "mistake":
+      return level === "beginner"
+        ? `A mistake. ${bestSan} was the right move here.`
+        : `A mistake that gave away ${pawns} pawns of advantage. ${bestSan} was correct.`;
+    case "blunder":
+      return level === "beginner"
+        ? `A blunder — this loses a lot. ${bestSan} was needed.`
+        : `A blunder losing ${pawns} pawns of advantage. ${bestSan} was necessary.`;
+    case "missed_win":
+      return level === "beginner"
+        ? `This lets a winning position slip away. ${bestSan} would have kept the advantage.`
+        : `Missed win — had a decisive advantage but ${playedSan} lets it escape. ${bestSan} would have maintained the win.`;
+    case "miss":
+      return `A missed opportunity. ${bestSan} was stronger.`;
+    default:
+      return `${playedSan} was played.`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Best-move explanation builder
+// ---------------------------------------------------------------------------
+
+function buildWhyBetter(
+  bestSan: string,
+  bestUci: string,
+  fenBefore: string,
+  themes: ChessTheme[],
+  phase: GamePhase,
+  level: "beginner" | "club" | "advanced"
+): string {
+  const themeSet = new Set(themes);
+  const from = bestUci.slice(0, 2);
+  const to = bestUci.slice(2, 4);
+
+  const board = new Chess(fenBefore);
+  const promoChar = bestUci[4];
+  let move: ReturnType<typeof board.move> | null = null;
+  try {
+    move = board.move(
+      promoChar !== undefined
+        ? { from, to, promotion: promoChar }
+        : { from, to }
+    );
+  } catch {
+    return `${bestSan} was the engine's top recommendation.`;
+  }
+  if (!move) return `${bestSan} was the engine's top recommendation.`;
+
+  const parts: string[] = [];
+
+  if (move.flags.includes("c") || move.flags.includes("e")) {
+    const captured = move.captured?.toUpperCase() ?? "piece";
+    const name =
+      captured === "Q" ? "queen" :
+      captured === "R" ? "rook" :
+      captured === "B" ? "bishop" :
+      captured === "N" ? "knight" : "pawn";
+    parts.push(`wins the ${name} on ${to}`);
+  }
+
+  if (move.flags.includes("+")) {
+    parts.push("gives check");
+  }
+
+  if (themeSet.has("fork_potential")) {
+    parts.push("creates a fork threat");
+  }
+  if (themeSet.has("king_safety") && phase !== "endgame") {
+    parts.push("improves king safety");
+  }
+  if (themeSet.has("piece_activity")) {
+    parts.push("activates a key piece");
+  }
+  if (themeSet.has("open_file")) {
+    parts.push("controls the open file");
+  }
+
+  if (parts.length === 0) {
+    if (phase === "opening") parts.push("improves piece development and central control");
+    else if (phase === "endgame") parts.push("improves king activity and pawn structure");
+    else parts.push("maintains better piece coordination");
+  }
+
+  const sentence = `${bestSan} ${parts.join(" and ")}.`;
+  return level === "beginner"
+    ? sentence
+    : `${sentence} The engine evaluates this as significantly stronger.`;
+}
+
+// ---------------------------------------------------------------------------
+// Takeaway builder
+// ---------------------------------------------------------------------------
+
+function buildTakeaway(
+  classification: MoveExplanation["classification"],
+  phase: GamePhase,
+  themes: ChessTheme[],
+  structures: PawnStructure[],
+  level: "beginner" | "club" | "advanced"
+): string {
+  const themeSet = new Set(themes);
+
+  if (classification === "best" || classification === "excellent" || classification === "good") {
+    return level === "beginner"
+      ? "Good move! Keep thinking about piece safety and central control."
+      : "Well played — this confirms your understanding of this position type.";
+  }
+
+  // Blunder-specific
+  if (classification === "blunder" || classification === "missed_win") {
+    if (phase === "opening") {
+      return level === "beginner"
+        ? "After each opening move, check: does my move hang a piece? Can my opponent attack something for free?"
+        : "Before committing to an opening move, verify no tactical shot is available to your opponent.";
+    }
+    if (themeSet.has("fork_potential")) {
+      return level === "beginner"
+        ? "Always check if your opponent's knight can jump to a square attacking two pieces at once."
+        : "Scan for knight fork possibilities before every move — they are easy to miss under time pressure.";
+    }
+    if (themeSet.has("back_rank")) {
+      return level === "beginner"
+        ? "Watch out for back-rank checkmate threats — make sure your king has an escape square."
+        : "Back-rank weaknesses require prophylaxis — an escape square or rook on the first rank.";
+    }
+    if (themeSet.has("king_safety")) {
+      return level === "beginner"
+        ? "Keep your king safe — avoid moves that open lines toward your own king."
+        : "Evaluate king safety before every tactical sequence — an unsafe king changes everything.";
+    }
+  }
+
+  // Mistake
+  if (classification === "mistake") {
+    if (themeSet.has("piece_activity")) {
+      return level === "beginner"
+        ? "Try to keep your pieces on active squares where they control important areas."
+        : "Piece activity often outweighs material equality — prefer active moves.";
+    }
+    if (phase === "endgame") {
+      return level === "beginner"
+        ? "In endgames, every pawn and king move matters — take your time."
+        : `In endgames with ${structures[0] ?? "this structure"}, precision is critical — calculate forcing lines.`;
+    }
+  }
+
+  // Inaccuracy
+  if (classification === "inaccuracy") {
+    if (phase === "opening") {
+      return level === "beginner"
+        ? "Study the main ideas of this opening — knowing the key moves helps avoid inaccuracies."
+        : "Review the critical branching points in this variation — small inaccuracies here compound later.";
+    }
+  }
+
+  // Generic fallback
+  return level === "beginner"
+    ? "After each move, ask: does this improve my position? Is anything hanging?"
+    : "Use this as a pattern to recognise — understanding why the engine's choice is better builds intuition.";
+}
+
+// ---------------------------------------------------------------------------
+// boardData builder
+// ---------------------------------------------------------------------------
+
+function buildBoardData(
+  pgn: string,
+  targetPly: number,
+  classification: MoveExplanation["classification"],
+  evalAfterCp: number,
+  playedFrom: string,
+  playedTo: string,
+  bestUci: string,
+  isBestMove: boolean,
+  assessment: string,
+  orientation: "white" | "black"
+): BoardData | null {
+  try {
+    const board = new Chess();
+    board.loadPgn(pgn);
+    const history = board.history({ verbose: true });
+
+    const replayBoard = new Chess();
+    const initialFen = replayBoard.fen();
+    const moves: BoardMove[] = [];
+
+    for (let i = 0; i < history.length; i++) {
+      const move = history[i];
+      if (!move) continue;
+      replayBoard.move(move.san);
+      const fen = replayBoard.fen();
+      const uci = move.from + move.to + (move.promotion ?? "");
+      const arrows: BoardArrow[] = [];
+
+      if (i === targetPly) {
+        // Arrow for played move
+        arrows.push({
+          from: playedFrom,
+          to: playedTo,
+          color: classToColor(classification),
+          label: null,
+          width: "thick",
+        });
+        // Arrow for best move (if different)
+        if (!isBestMove && bestUci.length >= 4) {
+          arrows.push({
+            from: bestUci.slice(0, 2),
+            to: bestUci.slice(2, 4),
+            color: "#4caf50",
+            label: "Best",
+            width: "normal",
+          });
+        }
+      }
+
+      moves.push({
+        ply: i + 1,
+        san: move.san,
+        fen,
+        uci,
+        eval: i === targetPly ? evalAfterCp : null,
+        classification: i === targetPly
+          ? (classification === "missed_win" ? "blunder" : classification)
+          : null,
+        annotation:
+          i === targetPly
+            ? assessment.slice(0, 200)
+            : null,
+        arrows,
+        clock: null,
+      });
+    }
+
+    const white = extractHeader(pgn, "White");
+    const black = extractHeader(pgn, "Black");
+    const whiteEloStr = extractHeader(pgn, "WhiteElo");
+    const blackEloStr = extractHeader(pgn, "BlackElo");
+    const eco = extractHeader(pgn, "ECO");
+    const openingName = extractHeader(pgn, "Opening");
+    const timeControl = extractHeader(pgn, "TimeControl");
+    const result = extractHeader(pgn, "Result");
+
+    const isKnown = (val: string) => val !== "Unknown";
+
+    return {
+      meta: { initialFen, orientation },
+      moves,
+      players: {
+        white: {
+          name: isKnown(white) ? white : "White",
+          rating: isKnown(whiteEloStr) ? parseInt(whiteEloStr, 10) : null,
+        },
+        black: {
+          name: isKnown(black) ? black : "Black",
+          rating: isKnown(blackEloStr) ? parseInt(blackEloStr, 10) : null,
+        },
+      },
+      opening:
+        isKnown(eco) && isKnown(openingName)
+          ? { eco, name: openingName, moves: "" }
+          : null,
+      result: isKnown(result) ? result : "*",
+      timeControl: isKnown(timeControl) ? timeControl : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Player rating helper
+// ---------------------------------------------------------------------------
+
+async function fetchPlayerRatingForLevel(
+  username: string,
+  platform: "chess.com" | "lichess"
+): Promise<number | null> {
+  try {
+    if (platform === "chess.com") {
+      const stats = await getChessComStats(username);
+      return (
+        stats.chess_rapid?.last?.rating ??
+        stats.chess_blitz?.last?.rating ??
+        stats.chess_bullet?.last?.rating ??
+        null
+      );
+    } else {
+      const profile = await getLichessProfile(username);
+      const perfs = profile.perfs;
+      return (
+        perfs?.rapid?.rating ??
+        perfs?.blitz?.rating ??
+        perfs?.bullet?.rating ??
+        null
+      );
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+export async function handleExplainMove(
+  input: ExplainMoveInput
+): Promise<MoveExplanation> {
+  // 1. Resolve PGN
+  if (
+    input.pgn === undefined &&
+    input.game_url === undefined &&
+    input.lichess_id === undefined &&
+    input.username === undefined
+  ) {
+    throw new Error(
+      "Please provide a game source: pgn, game_url, lichess_id, or username."
+    );
+  }
+
+  const pgn = await resolvePgn(input);
+
+  // 2. Parse & navigate to target ply
+  const board = new Chess();
+  board.loadPgn(pgn);
+  const history = board.history({ verbose: true });
+
+  const targetPly =
+    (input.move_number - 1) * 2 + (input.color === "black" ? 1 : 0);
+
+  if (targetPly >= history.length || targetPly < 0) {
+    throw new Error(
+      `Move ${input.move_number} ${input.color} is out of range — this game has ${Math.ceil(history.length / 2)} full moves.`
+    );
+  }
+
+  // fenBefore is the position BEFORE the target move
+  const replayBoard2 = new Chess();
+  for (let i = 0; i < targetPly; i++) {
+    const h = history[i];
+    if (h) replayBoard2.move(h.san);
+  }
+  const fenBefore = replayBoard2.fen();
+
+  const replayBoard3 = new Chess();
+  for (let i = 0; i <= targetPly; i++) {
+    const h = history[i];
+    if (h) replayBoard3.move(h.san);
+  }
+  const fenAfter = replayBoard3.fen();
+
+  const playedMove = history[targetPly];
+  if (!playedMove) {
+    throw new Error(`No move found at ply ${targetPly}.`);
+  }
+  const playedUci =
+    playedMove.from + playedMove.to + (playedMove.promotion ?? "");
+
+  // 3. Wait for engine
+  await waitUntilRouterReady(config.stockfish.readinessTimeout);
+
+  // 4. Evaluate in parallel
+  const depth = input.depth ?? config.stockfish.defaultDepth;
+  const [linesBefore, linesAfter] = await Promise.all([
+    getEval(fenBefore, depth, 3),
+    getEval(fenAfter, depth, 1),
+  ]);
+
+  const evalBeforeCp =
+    linesBefore.length > 0 && linesBefore[0] ? lineToEvalCp(linesBefore[0]) : 0;
+  const evalAfterCp =
+    linesAfter.length > 0 && linesAfter[0] ? lineToEvalCp(linesAfter[0]) : 0;
+
+  // 5. Normalize eval drop (side-to-move, immune to Issue #85)
+  const evalBeforeStm = evalForSideToMove(evalBeforeCp, input.color);
+  const evalAfterStm = evalForSideToMove(evalAfterCp, input.color);
+  // bestUci needs to be known before evalDrop for the isBestMove check below.
+  // We compute it early here so we can zero out the drop when the best move was played.
+  const bestUciEarly = linesBefore[0]?.pv[0] ?? "";
+  const isBestMoveEarly = bestUciEarly === playedUci;
+  // If the player played the best move, eval drop is defined as 0 regardless of
+  // centipawn rounding differences between the two evaluations.
+  const evalDropCp = isBestMoveEarly ? 0 : Math.max(0, evalBeforeStm - evalAfterStm);
+
+  // 6. Classify
+  const bestUci = bestUciEarly;
+  const isBestMove = isBestMoveEarly;
+  const hadWinning = evalBeforeStm >= 300;
+  const isNowLosing = evalAfterStm <= -50;
+
+  let classification: MoveExplanation["classification"];
+  if (isBestMove) {
+    classification = "best";
+  } else {
+    const cat = categorise(evalDropCp, hadWinning, isNowLosing);
+    classification =
+      cat === "missed_win"
+        ? "missed_win"
+        : cat === "blunder"
+        ? "blunder"
+        : cat === "mistake"
+        ? "mistake"
+        : cat === "inaccuracy"
+        ? "inaccuracy"
+        : "good";
+  }
+
+  // 7. Convert best move UCI → SAN, build continuations
+  const fenBoard = new Chess(fenBefore);
+  const bestSan = bestUci ? uciToSan(fenBoard, bestUci) : "";
+  const bestContinuation =
+    linesBefore[0]?.pv
+      ? pvToSan(new Chess(fenBefore), linesBefore[0].pv.slice(0, 4))
+      : [];
+
+  const altLine = linesBefore[1];
+  const altUci = altLine?.pv[0] ?? "";
+  const altSan = altUci ? uciToSan(new Chess(fenBefore), altUci) : "";
+  const altContinuation = altLine?.pv
+    ? pvToSan(new Chess(fenBefore), altLine.pv.slice(0, 4))
+    : [];
+
+  // 8. Position context
+  const posBoard = new Chess(fenBefore);
+  const phase = classifyPhase(posBoard);
+  const structures = classifyPawnStructure(posBoard);
+  const themes = tagThemes(posBoard, phase);
+  const { advantage: materialBalance } = getMaterialBalance(posBoard);
+  const narrative = generateNarrative(
+    phase,
+    structures,
+    themes,
+    evalBeforeCp,
+    null
+  );
+
+  // 9. Player level
+  let level: "beginner" | "club" | "advanced";
+  if (input.player_level) {
+    level = input.player_level;
+  } else if (input.username && input.platform) {
+    const rating = await fetchPlayerRatingForLevel(
+      input.username,
+      input.platform
+    );
+    level = rating !== null ? detectPlayerLevel(rating) : "club";
+  } else {
+    level = "club";
+  }
+
+  // 10. Build move intent
+  const moveIntent = buildMoveIntent(
+    playedMove as VerboseMove,
+    themes,
+    phase,
+    level
+  );
+
+  // 11. Build assessment
+  const assessment = buildAssessment(
+    classification,
+    evalDropCp,
+    playedMove.san,
+    bestSan,
+    level
+  );
+
+  // 12. Build best move explanation
+  const bestMoveResult: MoveExplanation["best_move"] = isBestMove
+    ? null
+    : {
+        san: bestSan,
+        uci: bestUci,
+        eval_cp: linesBefore[0]?.score_cp ?? null,
+        eval_mate: linesBefore[0]?.score_mate ?? null,
+        continuation: bestContinuation,
+        why_better: buildWhyBetter(
+          bestSan,
+          bestUci,
+          fenBefore,
+          themes,
+          phase,
+          level
+        ),
+      };
+
+  // Alternative (second engine line)
+  const alternativeResult: MoveExplanation["alternative"] =
+    altSan && altUci && altUci !== playedUci && altUci !== bestUci
+      ? {
+          san: altSan,
+          uci: altUci,
+          eval_cp: altLine?.score_cp ?? null,
+          eval_mate: altLine?.score_mate ?? null,
+          continuation: altContinuation,
+        }
+      : null;
+
+  // 13. Takeaway
+  const takeaway = buildTakeaway(classification, phase, themes, structures, level);
+
+  // 14. boardData
+  const boardData = buildBoardData(
+    pgn,
+    targetPly,
+    classification,
+    evalAfterCp,
+    playedMove.from,
+    playedMove.to,
+    bestUci,
+    isBestMove,
+    assessment,
+    input.color
+  );
+
+  // fenAfter is computed but used only for potential future expansion
+  void fenAfter;
+
+  // 15. Return
+  return {
+    move_number: input.move_number,
+    color: input.color,
+    move_played: playedMove.san,
+    move_played_uci: playedUci,
+    classification,
+    eval_before_cp: evalBeforeCp,
+    eval_after_cp: evalAfterCp,
+    eval_drop_cp: evalDropCp,
+    move_intent: moveIntent,
+    assessment,
+    best_move: bestMoveResult,
+    alternative: alternativeResult,
+    position_context: {
+      phase,
+      themes,
+      pawn_structures: structures,
+      material_balance: materialBalance,
+      narrative,
+    },
+    takeaway,
+    player_level: level,
+    board_data: boardData,
+  };
+}

--- a/mcp-server/src/types/index.ts
+++ b/mcp-server/src/types/index.ts
@@ -556,3 +556,149 @@ export interface GeneratePuzzlesOutput {
   games_scanned: number;
   note?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Board Artifact (Issue #91 — boardData standard)
+// ---------------------------------------------------------------------------
+
+export interface BoardArrow {
+  from: string;
+  to: string;
+  color: string;
+  label: string | null;
+  width: "thin" | "normal" | "thick";
+}
+
+export interface BoardMove {
+  ply: number;
+  san: string;
+  fen: string;
+  uci: string;
+  eval: number | null;
+  classification:
+    | "brilliant"
+    | "best"
+    | "excellent"
+    | "good"
+    | "inaccuracy"
+    | "mistake"
+    | "blunder"
+    | "miss"
+    | "book"
+    | null;
+  annotation: string | null;
+  arrows: BoardArrow[];
+  clock: number | null;
+}
+
+export interface BoardData {
+  meta: {
+    initialFen: string;
+    orientation: "white" | "black";
+  };
+  moves: BoardMove[];
+  players: {
+    white: { name: string; rating: number | null };
+    black: { name: string; rating: number | null };
+  };
+  opening: { eco: string; name: string; moves: string } | null;
+  result: string;
+  timeControl: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// explain_move tool (Issue #87)
+// ---------------------------------------------------------------------------
+
+export const ExplainMoveInputSchema = z.object({
+  move_number: z
+    .number()
+    .int()
+    .min(1)
+    .describe("The full-move number to explain (e.g. 15 means move 15)"),
+  color: z
+    .enum(["white", "black"])
+    .describe("Which side's move to explain at that move number"),
+  pgn: z.string().optional().describe("Raw PGN text of the game"),
+  game_url: z
+    .string()
+    .optional()
+    .describe("Chess.com or Lichess game URL"),
+  lichess_id: z
+    .string()
+    .optional()
+    .describe("Lichess game ID (8-character string)"),
+  username: z
+    .string()
+    .optional()
+    .describe(
+      "Chess.com or Lichess username — if no other source is given, uses their most recent game"
+    ),
+  platform: z
+    .enum(["chess.com", "lichess"])
+    .optional()
+    .describe("Required when source is a username without a URL"),
+  player_level: z
+    .enum(["beginner", "club", "advanced"])
+    .optional()
+    .describe(
+      "Override automatic level detection. Auto-detected from rating when username+platform provided."
+    ),
+  depth: z
+    .number()
+    .int()
+    .min(1)
+    .max(25)
+    .optional()
+    .describe("Engine analysis depth (default: 18)"),
+});
+
+export type ExplainMoveInput = z.infer<typeof ExplainMoveInputSchema>;
+
+export interface MoveExplanation {
+  move_number: number;
+  color: "white" | "black";
+  move_played: string;
+  move_played_uci: string;
+  classification:
+    | "brilliant"
+    | "best"
+    | "excellent"
+    | "good"
+    | "inaccuracy"
+    | "mistake"
+    | "blunder"
+    | "miss"
+    | "missed_win"
+    | "book";
+  eval_before_cp: number;
+  eval_after_cp: number;
+  eval_drop_cp: number;
+  move_intent: string;
+  assessment: string;
+  best_move: {
+    san: string;
+    uci: string;
+    eval_cp: number | null;
+    eval_mate: number | null;
+    continuation: string[];
+    why_better: string;
+  } | null;
+  alternative: {
+    san: string;
+    uci: string;
+    eval_cp: number | null;
+    eval_mate: number | null;
+    continuation: string[];
+  } | null;
+  position_context: {
+    phase: GamePhase;
+    themes: ChessTheme[];
+    pawn_structures: PawnStructure[];
+    material_balance: number;
+    narrative: string;
+  };
+  takeaway: string;
+  player_level: "beginner" | "club" | "advanced";
+  board_data: BoardData | null;
+}


### PR DESCRIPTION
## Summary

- Adds `explain_move` MCP tool (Closes #87)
- Lays groundwork for board artifact standard (Part of #91)

**What the tool does:** Given any chess game and a move number, explains why the move was played, classifies it (best/good/inaccuracy/mistake/blunder), shows the engine's recommendation with a plain-English explanation of why it's better, and returns an actionable takeaway adapted to the player's level.

**Accepted game sources:** PGN text · chess.com URL · lichess URL · username (uses most recent game)

## Changes

### New
- `src/tools/explain-move.ts` — full handler
- `src/tools/explain-move.test.ts` — 8 unit tests

### Additive exports (zero behavior change)
- `analyze-game.ts` → exported `resolvePgn`, `extractHeader`, `lineToEvalCp`
- `analyze-position.ts` → exported `uciToSan`, `pvToSan`
- `intelligence/critical-moments.ts` → exported `evalForSideToMove`, `categorise`

### New types
- `BoardArrow`, `BoardMove`, `BoardData` — Issue #91 board artifact standard
- `ExplainMoveInputSchema`, `ExplainMoveInput`, `MoveExplanation`

## Key design decisions

- **Eval normalization is explicit** — immune to the Issue #85 POV bug. Normalizes `evalBeforeCp`/`evalAfterCp` to side-to-move perspective before computing drop, regardless of engine output convention
- **Two parallel engine calls** — `getEval(fenBefore, depth, 3)` for alternatives + `getEval(fenAfter, depth, 1)` for result eval. Both benefit from the existing SQLite eval cache
- **Full game in `boardData`** — all moves included for navigation context, only the target ply annotated with arrows and classification
- **Player level auto-detection** — fetches rating from chess.com/lichess when `username + platform` provided, falls back to "club"

## Test plan

- [x] Build passes (`npm run build`)
- [x] 8/8 unit tests pass (`npx vitest run src/tools/explain-move.test.ts`)
- [x] Full suite: 358/359 (1 pre-existing failure in integration test — issue #90)
- [x] Manual: ask Claude "explain move 15 by white in my last chess.com game notsobrillantmove"
- [ ] Manual: paste a PGN and ask "explain move 8 by black"
- [ ] Manual: verify `board_data` is present and Claude renders an SVG artifact