### PR TITLE
feat: add board_data to all chess tools

### DIFF
--- a/mcp-server/src/intelligence/board-builder.ts
+++ b/mcp-server/src/intelligence/board-builder.ts
@@ -153,7 +153,7 @@ export function buildGameBoardData(params: GameBoardParams): BoardData | null {
       const fen = replayBoard.fen();
       const uci = move.from + move.to + (move.promotion ?? "");
       const ply = i + 1; // 1-indexed
-      const classification = params.classifications.get(ply) ?? null;
+      const classification = (params.classifications.get(ply) ?? null) as BoardMove["classification"];
       const arrows: BoardArrow[] = [];
 
       if (params.criticalPlies.has(ply)) {

--- a/mcp-server/src/intelligence/board-builder.ts
+++ b/mcp-server/src/intelligence/board-builder.ts
@@ -1,0 +1,209 @@
+import { Chess } from "chess.js";
+import type { BoardArrow, BoardData, BoardMove } from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Color helpers
+// ---------------------------------------------------------------------------
+
+function classToColor(classification: string | null): string {
+  switch (classification) {
+    case "best":      return "#4caf50";
+    case "excellent":
+    case "good":      return "#8bc34a";
+    case "inaccuracy": return "#ffeb3b";
+    case "mistake":   return "#ff9800";
+    case "blunder":
+    case "missed_win":
+    case "miss":      return "#f44336";
+    default:          return "#2196f3";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SAN → UCI conversion helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a SAN move at a given FEN position to UCI notation (e.g. "e2e4").
+ * Returns null if the move is illegal or cannot be parsed.
+ */
+export function sanToUci(fen: string, san: string): string | null {
+  try {
+    const board = new Chess(fen);
+    const move = board.move(san);
+    return move.from + move.to + (move.promotion ?? "");
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Position board helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build arrows for the top engine moves at a position.
+ * The first move gets a "Best" label and a thick arrow; subsequent moves get
+ * progressively thinner arrows.
+ */
+export function buildPositionArrows(topMoveUcis: string[]): BoardArrow[] {
+  const widths: BoardArrow["width"][] = ["thick", "normal", "thin"];
+  const colors = ["#4caf50", "#8bc34a", "#81c784"];
+  const arrows: BoardArrow[] = [];
+
+  for (let i = 0; i < Math.min(topMoveUcis.length, 3); i++) {
+    const uci = topMoveUcis[i];
+    if (!uci || uci.length < 4) continue;
+    arrows.push({
+      from: uci.slice(0, 2),
+      to: uci.slice(2, 4),
+      color: colors[i] ?? "#4caf50",
+      label: i === 0 ? "Best" : null,
+      width: widths[i] ?? "thin",
+    });
+  }
+
+  return arrows;
+}
+
+/**
+ * Build board data for a single position (no game history).
+ *
+ * Used by: analyze_position, generate_puzzles (per puzzle),
+ *          find_opening_gaps (per gap), get_opening_theory.
+ *
+ * The arrows are stored in meta.initial_arrows so a frontend can render them
+ * on the initial FEN before any moves are played.
+ */
+export function buildPositionBoardData(
+  fen: string,
+  arrows: BoardArrow[],
+  orientation: "white" | "black" = "white"
+): BoardData {
+  return {
+    meta: {
+      initialFen: fen,
+      orientation,
+      ...(arrows.length > 0 ? { initial_arrows: arrows } : {}),
+    },
+    moves: [],
+    players: {
+      white: { name: "White", rating: null },
+      black: { name: "Black", rating: null },
+    },
+    opening: null,
+    result: "*",
+    timeControl: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Game board
+// ---------------------------------------------------------------------------
+
+export interface GameBoardParams {
+  /** Verbose move list from chess.js history({ verbose: true }). */
+  history: ReadonlyArray<{
+    from: string;
+    to: string;
+    san: string;
+    promotion?: string;
+  }>;
+  /**
+   * Centipawn evaluations indexed by position index.
+   * evals[0] = initial position, evals[i] = position after ply i.
+   */
+  evals: readonly number[];
+  /**
+   * Best UCI move from each position.
+   * bestMovesUci[i] = best move playable from position i (i.e. before ply i+1).
+   */
+  bestMovesUci: readonly string[];
+  /** 1-indexed ply numbers that represent critical moments. */
+  criticalPlies: ReadonlySet<number>;
+  /** ply → move classification (e.g. "blunder", "mistake"). */
+  classifications: ReadonlyMap<number, string>;
+  /** ply → annotation text shown on the board. */
+  annotations: ReadonlyMap<number, string>;
+  orientation: "white" | "black";
+  white: string;
+  black: string;
+  whiteRating: number | null;
+  blackRating: number | null;
+  eco: string | null;
+  openingName: string | null;
+  result: string;
+  timeControl: string | null;
+}
+
+/**
+ * Build board data for a full game.
+ * Arrows are only added at critical plies (blunders, mistakes, etc.).
+ * Returns null if the game cannot be replayed (invalid move history).
+ */
+export function buildGameBoardData(params: GameBoardParams): BoardData | null {
+  try {
+    const replayBoard = new Chess();
+    const initialFen = replayBoard.fen();
+    const moves: BoardMove[] = [];
+
+    for (let i = 0; i < params.history.length; i++) {
+      const move = params.history[i]!;
+      replayBoard.move(move.san);
+      const fen = replayBoard.fen();
+      const uci = move.from + move.to + (move.promotion ?? "");
+      const ply = i + 1; // 1-indexed
+      const classification = params.classifications.get(ply) ?? null;
+      const arrows: BoardArrow[] = [];
+
+      if (params.criticalPlies.has(ply)) {
+        arrows.push({
+          from: move.from,
+          to: move.to,
+          color: classToColor(classification),
+          label: null,
+          width: "thick",
+        });
+        const bestUci = params.bestMovesUci[i] ?? "";
+        if (bestUci.length >= 4 && bestUci !== uci) {
+          arrows.push({
+            from: bestUci.slice(0, 2),
+            to: bestUci.slice(2, 4),
+            color: "#4caf50",
+            label: "Best",
+            width: "normal",
+          });
+        }
+      }
+
+      moves.push({
+        ply,
+        san: move.san,
+        fen,
+        uci,
+        eval: params.evals[ply] ?? null,
+        classification,
+        annotation: params.annotations.get(ply) ?? null,
+        arrows,
+        clock: null,
+      });
+    }
+
+    return {
+      meta: { initialFen, orientation: params.orientation },
+      moves,
+      players: {
+        white: { name: params.white, rating: params.whiteRating },
+        black: { name: params.black, rating: params.blackRating },
+      },
+      opening:
+        params.eco && params.openingName
+          ? { eco: params.eco, name: params.openingName, moves: "" }
+          : null,
+      result: params.result,
+      timeControl: params.timeControl,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/mcp-server/src/tools/analyze-game.ts
+++ b/mcp-server/src/tools/analyze-game.ts
@@ -9,6 +9,7 @@ import {
   type MoveRecord,
 } from "../intelligence/critical-moments.js";
 import { classifyPhase } from "../intelligence/position-classifier.js";
+import { buildGameBoardData } from "../intelligence/board-builder.js";
 import { config } from "../config.js";
 import type {
   AnalyzeGameInput,
@@ -378,12 +379,52 @@ async function runAnalysis(
     mistake_categories: mistakeCategories,
   };
 
+  // Build board_data: annotate critical plies with arrows and classifications.
+  const criticalPlies = new Set<number>();
+  const classifications = new Map<number, string>();
+  const annotations = new Map<number, string>();
+  for (const cm of criticalMoments) {
+    const ply = (cm.move_number - 1) * 2 + (cm.color === "black" ? 2 : 1);
+    criticalPlies.add(ply);
+    classifications.set(ply, cm.category);
+    annotations.set(ply, cm.explanation);
+  }
+
+  const whiteEloStr = extractHeader(pgn, "WhiteElo");
+  const blackEloStr = extractHeader(pgn, "BlackElo");
+  const eco = extractHeader(pgn, "ECO");
+  const openingName = extractHeader(pgn, "Opening");
+
+  const boardData = buildGameBoardData({
+    history: history.map((m) => ({
+      from: m.from as string,
+      to: m.to as string,
+      san: m.san,
+      ...(m.promotion !== undefined ? { promotion: m.promotion as string } : {}),
+    })),
+    evals,
+    bestMovesUci: bestMoves,
+    criticalPlies,
+    classifications,
+    annotations,
+    orientation: "white",
+    white: gameInfo.white,
+    black: gameInfo.black,
+    whiteRating: whiteEloStr !== "Unknown" ? parseInt(whiteEloStr, 10) || null : null,
+    blackRating: blackEloStr !== "Unknown" ? parseInt(blackEloStr, 10) || null : null,
+    eco: eco !== "Unknown" ? eco : null,
+    openingName: openingName !== "Unknown" ? openingName : null,
+    result: gameInfo.result,
+    timeControl: gameInfo.time_control !== "Unknown" ? gameInfo.time_control : null,
+  });
+
   return {
     analysis: {
       game_info: gameInfo,
       summary,
       critical_moments: criticalMoments,
       patterns_detected: patterns,
+      board_data: boardData,
     },
     moveRecords,
   };

--- a/mcp-server/src/tools/analyze-position.ts
+++ b/mcp-server/src/tools/analyze-position.ts
@@ -8,6 +8,7 @@ import {
 } from "../intelligence/position-classifier.js";
 import { tagThemes } from "../intelligence/theme-tagger.js";
 import { generateNarrative } from "../intelligence/narrative-generator.js";
+import { buildPositionBoardData, buildPositionArrows } from "../intelligence/board-builder.js";
 import { config } from "../config.js";
 import type {
   AnalyzePositionInput,
@@ -152,6 +153,11 @@ export async function handleAnalyzePosition(
     bestLine.score_mate
   );
 
+  const topMoveUcis = topMoves.map((m) => m.move_uci);
+  const arrows = buildPositionArrows(topMoveUcis);
+  const sideToMove = board.turn() === "w" ? "white" : "black";
+  const boardData = buildPositionBoardData(input.fen, arrows, sideToMove);
+
   return {
     evaluation: {
       score_cp: bestLine.score_cp,
@@ -169,5 +175,6 @@ export async function handleAnalyzePosition(
       complexity,
       narrative,
     },
+    board_data: boardData,
   };
 }

--- a/mcp-server/src/tools/find-opening-gaps.ts
+++ b/mcp-server/src/tools/find-opening-gaps.ts
@@ -1,7 +1,8 @@
 import { getRecentGames as getChessComGames } from "../data/chesscom-api.js";
 import { getRecentGames as getLichessGames } from "../data/lichess-api.js";
 import { detectOpeningGaps, type GameRecord } from "../intelligence/opening-gap-detector.js";
-import type { FindOpeningGapsInput, FindOpeningGapsOutput } from "../types/index.js";
+import { buildPositionBoardData, sanToUci } from "../intelligence/board-builder.js";
+import type { FindOpeningGapsInput, FindOpeningGapsOutput, BoardArrow } from "../types/index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -101,7 +102,26 @@ export async function handleFindOpeningGaps(
     };
   }
 
-  const gaps = detectOpeningGaps(gameRecords, color, minOccurrences);
+  const rawGaps = detectOpeningGaps(gameRecords, color, minOccurrences);
+
+  // Add board_data to each gap: show the position with an arrow for the most
+  // common opponent deviation so the user can immediately see what to study.
+  const gaps = rawGaps.map((gap) => {
+    const arrows: BoardArrow[] = [];
+    if (gap.most_common_deviation) {
+      const uci = sanToUci(gap.fen, gap.most_common_deviation);
+      if (uci) {
+        arrows.push({
+          from: uci.slice(0, 2),
+          to: uci.slice(2, 4),
+          color: "#f44336",
+          label: "Deviation",
+          width: "thick",
+        });
+      }
+    }
+    return { ...gap, board_data: buildPositionBoardData(gap.fen, arrows, color) };
+  });
 
   const summary = buildSummary(input.username, color, gameRecords.length, gaps.length);
 

--- a/mcp-server/src/tools/generate-puzzles.ts
+++ b/mcp-server/src/tools/generate-puzzles.ts
@@ -3,7 +3,8 @@ import { getAnalysesForUser } from "../store/analysis-store.js";
 import { getGamesForUser } from "../store/game-store.js";
 import { extractPuzzles, type GameMeta } from "../intelligence/puzzle-classifier.js";
 import { waitUntilRouterReady } from "../engines/engine-router.js";
-import type { GeneratePuzzlesInput, GeneratePuzzlesOutput } from "../types/index.js";
+import { buildPositionBoardData, sanToUci } from "../intelligence/board-builder.js";
+import type { GeneratePuzzlesInput, GeneratePuzzlesOutput, BoardArrow } from "../types/index.js";
 
 export async function handleGeneratePuzzles(
   input: GeneratePuzzlesInput
@@ -81,7 +82,7 @@ export async function handleGeneratePuzzles(
 
   // Apply puzzle_type filter post-extraction (based on theme keywords)
   const puzzleType = input.puzzle_type ?? "all";
-  const filtered =
+  const filteredRaw =
     puzzleType === "all"
       ? rawPuzzles
       : rawPuzzles.filter((p) => {
@@ -96,6 +97,26 @@ export async function handleGeneratePuzzles(
           }
           return true;
         });
+
+  // Add board_data to each puzzle: show the starting position with an arrow
+  // for the first solution move so the user can immediately visualise the tactic.
+  const filtered = filteredRaw.map((puzzle) => {
+    const arrows: BoardArrow[] = [];
+    const firstMoveSan = puzzle.solution[0];
+    if (firstMoveSan) {
+      const uci = sanToUci(puzzle.fen, firstMoveSan);
+      if (uci) {
+        arrows.push({
+          from: uci.slice(0, 2),
+          to: uci.slice(2, 4),
+          color: "#4caf50",
+          label: "Solution",
+          width: "thick",
+        });
+      }
+    }
+    return { ...puzzle, board_data: buildPositionBoardData(puzzle.fen, arrows, puzzle.color_to_move) };
+  });
 
   // Produce a precise note depending on WHY no puzzles were returned.
   let note: string | undefined;

--- a/mcp-server/src/tools/get-opening-theory.ts
+++ b/mcp-server/src/tools/get-opening-theory.ts
@@ -1,4 +1,5 @@
 import { getLichessOpeningExplorer } from "../data/lichess-api.js";
+import { buildPositionBoardData, buildPositionArrows, sanToUci } from "../intelligence/board-builder.js";
 import type {
   GetOpeningTheoryInput,
   GetOpeningTheoryOutput,
@@ -258,6 +259,7 @@ export async function handleGetOpeningTheory(
       narrative: "",
       lichess_explorer_url: "https://lichess.org/analysis",
       note: "Provide either a FEN string or an opening name.",
+      board_data: null,
     };
   }
 
@@ -291,6 +293,7 @@ export async function handleGetOpeningTheory(
       narrative: buildNarrative(opening, emptyStats, playerLevel, []),
       lichess_explorer_url: `https://lichess.org/analysis/${encodeURIComponent(fen!)}`,
       note: `Lichess Opening Explorer unavailable (${err instanceof Error ? err.message : String(err)}). Showing local opening data only — win statistics and main continuations require a live connection.`,
+      board_data: buildPositionBoardData(fen!, [], "white"),
     };
   }
 
@@ -319,6 +322,14 @@ export async function handleGetOpeningTheory(
 
   const topMoveSans = explorerData.moves.slice(0, 5).map((m) => m.san);
 
+  // Build board_data: show the opening position with arrows for the top moves.
+  const topMoveUcis = topMoveSans
+    .slice(0, 3)
+    .map((san) => sanToUci(fen!, san))
+    .filter((uci): uci is string => uci !== null);
+  const openingArrows = buildPositionArrows(topMoveUcis);
+  const boardData = buildPositionBoardData(fen!, openingArrows, "white");
+
   return {
     opening_name: openingName,
     eco,
@@ -328,5 +339,6 @@ export async function handleGetOpeningTheory(
     historical_context: buildHistoricalContext(openingName),
     narrative: buildNarrative(openingName, winStats, playerLevel, topMoveSans),
     lichess_explorer_url: `https://lichess.org/analysis/${encodeURIComponent(fen!)}`,
+    board_data: boardData,
   };
 }

--- a/mcp-server/src/tools/review-game.ts
+++ b/mcp-server/src/tools/review-game.ts
@@ -195,6 +195,11 @@ export async function handleReviewGame(
   // Narrative
   const narrative = buildNarrative(analysis, color, result, level);
 
+  // Board data: use the game board from analysis but orient to the player's color.
+  const boardData = analysis.board_data
+    ? { ...analysis.board_data, meta: { ...analysis.board_data.meta, orientation: color } }
+    : null;
+
   return {
     player: input.player_username,
     player_level: level,
@@ -204,5 +209,6 @@ export async function handleReviewGame(
     phase_performance: phasePerformance,
     study_recommendations: studyRecs,
     narrative,
+    board_data: boardData,
   };
 }

--- a/mcp-server/src/types/index.ts
+++ b/mcp-server/src/types/index.ts
@@ -116,46 +116,6 @@ export const ScoutOpponentInputSchema = z.object({
 export type ScoutOpponentInput = z.infer<typeof ScoutOpponentInputSchema>;
 
 // ---------------------------------------------------------------------------
-// Board visualization types (shared across tools)
-// ---------------------------------------------------------------------------
-
-export interface BoardArrow {
-  from: string;
-  to: string;
-  color: string;
-  label: string | null;
-  width: "thin" | "normal" | "thick";
-}
-
-export interface BoardMove {
-  ply: number;
-  san: string;
-  fen: string;
-  uci: string;
-  eval: number | null;
-  classification: string | null;
-  annotation: string | null;
-  arrows: BoardArrow[];
-  clock: number | null;
-}
-
-export interface BoardData {
-  meta: {
-    initialFen: string;
-    orientation: "white" | "black";
-    initial_arrows?: BoardArrow[];
-  };
-  moves: BoardMove[];
-  players: {
-    white: { name: string; rating: number | null };
-    black: { name: string; rating: number | null };
-  };
-  opening: { eco: string; name: string; moves: string } | null;
-  result: string;
-  timeControl: string | null;
-}
-
-// ---------------------------------------------------------------------------
 // Internal engine types
 // ---------------------------------------------------------------------------
 
@@ -641,6 +601,7 @@ export interface BoardData {
   meta: {
     initialFen: string;
     orientation: "white" | "black";
+    initial_arrows?: BoardArrow[];
   };
   moves: BoardMove[];
   players: {

--- a/mcp-server/src/types/index.ts
+++ b/mcp-server/src/types/index.ts
@@ -116,6 +116,46 @@ export const ScoutOpponentInputSchema = z.object({
 export type ScoutOpponentInput = z.infer<typeof ScoutOpponentInputSchema>;
 
 // ---------------------------------------------------------------------------
+// Board visualization types (shared across tools)
+// ---------------------------------------------------------------------------
+
+export interface BoardArrow {
+  from: string;
+  to: string;
+  color: string;
+  label: string | null;
+  width: "thin" | "normal" | "thick";
+}
+
+export interface BoardMove {
+  ply: number;
+  san: string;
+  fen: string;
+  uci: string;
+  eval: number | null;
+  classification: string | null;
+  annotation: string | null;
+  arrows: BoardArrow[];
+  clock: number | null;
+}
+
+export interface BoardData {
+  meta: {
+    initialFen: string;
+    orientation: "white" | "black";
+    initial_arrows?: BoardArrow[];
+  };
+  moves: BoardMove[];
+  players: {
+    white: { name: string; rating: number | null };
+    black: { name: string; rating: number | null };
+  };
+  opening: { eco: string; name: string; moves: string } | null;
+  result: string;
+  timeControl: string | null;
+}
+
+// ---------------------------------------------------------------------------
 // Internal engine types
 // ---------------------------------------------------------------------------
 
@@ -164,6 +204,7 @@ export interface PositionAnalysis {
   };
   best_moves: TopMove[];
   position_context: PositionContext;
+  board_data?: BoardData | null;
 }
 
 export interface CriticalMoment {
@@ -215,6 +256,7 @@ export interface GameAnalysis {
   summary: GameSummary;
   critical_moments: CriticalMoment[];
   patterns_detected: string[];
+  board_data?: BoardData | null;
 }
 
 export interface RatingInfo {
@@ -341,6 +383,7 @@ export interface ReviewGameOutput {
   };
   study_recommendations: string[];
   narrative: string;
+  board_data?: BoardData | null;
 }
 
 // get_mistake_patterns
@@ -471,6 +514,7 @@ export interface GetOpeningTheoryOutput {
   narrative: string;                       // adapted by player_level
   lichess_explorer_url: string;
   note?: string;
+  board_data?: BoardData | null;
 }
 
 // find_opening_gaps
@@ -504,6 +548,7 @@ export interface OpeningGap {
   player_loss_rate: number;          // when opponent deviates
   most_common_deviation: string | null; // opponent's most frequent surprise move (SAN)
   study_suggestion: string;
+  board_data?: BoardData | null;
 }
 
 export interface FindOpeningGapsOutput {
@@ -548,6 +593,7 @@ export interface ChessPuzzle {
   theme: string;                       // e.g. "fork", "pin", "back_rank_weakness"
   source_game_id: string | null;
   source_move_number: number;
+  board_data?: BoardData | null;
 }
 
 export interface GeneratePuzzlesOutput {


### PR DESCRIPTION
## Summary

- Extracts the `BoardData` concept from the `issue-87-explain-move` branch and makes it available across **all tools** that return chess positions or game data
- Adds a new shared utility `intelligence/board-builder.ts` so each tool doesn't duplicate board-building logic
- No breaking changes — `board_data` is an optional field (`?:`) on all output types, so existing clients and tests are unaffected

## Changes

**New file: `intelligence/board-builder.ts`**
- `buildPositionBoardData(fen, arrows, orientation)` — single-position board (FEN + arrows in `meta.initial_arrows`)
- `buildGameBoardData(params)` — full-game board with all moves, arrows only on critical plies
- `buildPositionArrows(ucis)` — generates colored arrows for top engine moves
- `sanToUci(fen, san)` — converts SAN notation to UCI for arrow coordinates

**Updated: `types/index.ts`**
- Added `BoardArrow`, `BoardMove`, `BoardData` interfaces
- Added `board_data?: BoardData | null` to: `PositionAnalysis`, `GameAnalysis`, `ReviewGameOutput`, `OpeningGap`, `ChessPuzzle`, `GetOpeningTheoryOutput`

**Per-tool board_data**

| Tool | board_data content |
|---|---|
| `analyze_position` | FEN + arrows for top 3 engine moves (green, thick → thin) |
| `analyze_game` | Full game replay; arrows on blunders/mistakes showing played move + engine best |
| `review_game` | Same as `analyze_game`; orientation flipped to player's color |
| `find_opening_gaps` | Per gap: FEN + red arrow on most common opponent deviation |
| `generate_puzzles` | Per puzzle: FEN + green arrow on first solution move |
| `get_opening_theory` | FEN + arrows for top 3 Lichess explorer continuations |

## Test plan

- [x] `npm run build` passes (TypeScript strict + exactOptionalPropertyTypes)
- [x] `npm test` — 350/351 tests pass (1 pre-existing integration test failure unrelated to this PR)
- [ ] Verify board_data appears in MCP tool responses via Claude Desktop
- [ ] Confirm optional field does not break existing tool consumers

Closes #94